### PR TITLE
Added checks for standard vs ha storage types in the outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,8 +156,6 @@ resource "aws_security_group" "nfs-sg" {
   tags = merge(var.tags, map("Name", "${var.prefix}-nfs-sg"))
 }
 
-
-
 # EFS File System - https://www.terraform.io/docs/providers/aws/r/efs_file_system.html
 resource "aws_efs_file_system" "efs-fs" {
   count            = var.storage_type == "ha" ? 1 : 0

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,7 @@ output "worker_iam_role_arn" {
 }
 
 output "rwx_filestore_id" {
-  value = element(coalescelist(aws_efs_file_system.efs-fs.*.id, [""]), 0)
+  value = var.storage_type == "ha" ? element(coalescelist(aws_efs_file_system.efs-fs.*.id, [""]), 0) : null
 }
 
 output "rwx_filestore_endpoint" {
@@ -25,7 +25,7 @@ output "rwx_filestore_path" {
 }
 
 output "efs_arn" {
-  value = element(coalescelist(aws_efs_file_system.efs-fs.*.arn, [""]), 0)
+  value = var.storage_type == "ha" ? element(coalescelist(aws_efs_file_system.efs-fs.*.arn, [""]), 0) : null
 }
 
 output "jump_private_ip" {


### PR DESCRIPTION
Adjusted - rwx_filestore_id and efs_arn to return null if not using ha storage type.