### PR TITLE
Added in logic to fix auto scaling node startup

### DIFF
--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -29,7 +29,7 @@ default_nodepool_custom_data            = ""
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 
-## Cluster Node Pools config - mimimal
+## Cluster Node Pools config - minimal
 cluster_node_pool_mode   = "minimal"
 node_pools = {
   cas = {

--- a/main.tf
+++ b/main.tf
@@ -324,7 +324,7 @@ locals {
         root_volume_size                     = np_value.os_disk_size
         root_volume_type                     = np_value.os_disk_type
         root_iops                            = np_value.os_disk_iops
-        asg_desired_capacity                 = var.autoscaling_enabled ? 1 : np_value.min_nodes # TODO - Remove when moving to managed nodes
+        asg_desired_capacity                 = var.autoscaling_enabled ? np_value.min_nodes == 0 ? 1 : np_value.min_nodes : np_value.min_nodes # TODO - Remove when moving to managed nodes
         asg_min_size                         = np_value.min_nodes
         asg_max_size                         = np_value.max_nodes
         kubelet_extra_args                   = "--node-labels=${replace(replace(jsonencode(np_value.node_labels), "/[\"\\{\\}]/", ""), ":", "=")} --register-with-taints=${join(",", np_value.node_taints)}"

--- a/variables.tf
+++ b/variables.tf
@@ -175,8 +175,8 @@ variable node_pools {
     os_disk_type                         = string
     os_disk_size                         = number
     os_disk_iops                         = number
-    min_nodes                            = string
-    max_nodes                            = string
+    min_nodes                            = number
+    max_nodes                            = number
     node_taints                          = list(string)
     node_labels                          = map(string)
     custom_data                          = string


### PR DESCRIPTION
Fixes: #77 

Added code which adjusted the `desired_capacity` of a node pool to `1` if the `autoscaling_enabled` variable is set to `true`. This allows the node pool to create at least 1 node for use. Since this is the `desired_cacaity` the value is honored upon node pool creation. However, in the spirit of auto scaling, if the nodes with with the `desired_capacity` value are not utilized the autoscaler will do its job.