### PR TITLE
Updates to tags and resource names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -357,7 +357,7 @@ locals {
 # EKS Setup - https://github.com/terraform-aws-modules/terraform-aws-eks
 module "eks" {
   source                                = "terraform-aws-modules/eks/aws"
-  version                               = "16.2.0"
+  version                               = "17.1.0"
   cluster_name                          = local.cluster_name
   cluster_version                       = var.kubernetes_version
   cluster_endpoint_private_access       = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,10 @@ output "kube_config" {
   value = module.kubeconfig.kube_config
 }
 
+output "cluster_iam_role_arn" {
+  value = module.eks.cluster_iam_role_arn
+}
+
 output "worker_iam_role_arn" {
   value = module.eks.worker_iam_role_arn
 }


### PR DESCRIPTION
Found where we added code for BYO IAM policies, this left the `cluster_iam_role_name` and `workers_role_name` with `terraform` as their prefix for the Roles being created. This makes it hard for folks to determine which roles using the AWS console were associated with a given cluster.