### PR TITLE
use subnet cidrs in nfs export instead of primary vpc cidr

### DIFF
--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -44,15 +44,18 @@ runcmd:
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/raid-config.html
   - mdadm --create --verbose /dev/md0 --level=0 --name=nfs-raid --raid-devices=4 $(lsblk -frnp | grep 'nvme' | grep -v 'nvme0' | xargs)
   - mkfs -t ext4 /dev/md0
-  - mdadm --detail --scan | tee -a /etc/mdadm.conf  
+  - mdadm --detail --scan | tee -a /etc/mdadm.conf
   # Update /etc/fstab
   #
   - echo "/dev/md0       /export        ext4        defaults,nofail,x-systemd.requires=cloud-init.service,barrier=0,discard        0  2" >>/etc/fstab
   - mount -a
   #
-  # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC
+  # Update /etc/exports
   #
-  - echo "/export         ${base_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - for cidr_block in ${public_subnet_cidrs} ${private_subnet_cidrs}
+  - do
+  -   echo "/export         $cidr_block(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - done
   #
   # Restart nfs-server service
   #

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,8 @@ data "template_file" "nfs-cloudconfig" {
 
   vars = {
     vm_admin        = var.nfs_vm_admin
-    base_cidr_block = module.vpc.vpc_cidr
+    public_subnet_cidrs  = join(" ", module.vpc.public_subnet_cidrs)
+    private_subnet_cidrs = join(" ", module.vpc.private_subnet_cidrs)
   }
 
 }

--- a/modules/aws_vpc/main.tf
+++ b/modules/aws_vpc/main.tf
@@ -36,7 +36,7 @@ resource "aws_vpc" "vpc" {
 
 resource "aws_vpc_endpoint" "private_endpoints" {
   count              = length(var.vpc_private_endpoints)
-  vpc_id             = aws_vpc.vpc.0.id
+  vpc_id             = local.vpc_id
   service_name       = "com.amazonaws.${var.region}.${var.vpc_private_endpoints[count.index]}"
   vpc_endpoint_type  = "Interface"
   security_group_ids = [ var.security_group_id ]
@@ -54,17 +54,17 @@ resource "aws_vpc_endpoint" "private_endpoints" {
 }
 
 data "aws_subnet" "public" {
-  count = local.existing_public_subnets ? 1 : 0
+  count = local.existing_public_subnets ? length(var.subnets["public"]) : 0
   id    = element(var.existing_subnet_ids["public"], count.index)
 }
 
 data "aws_subnet" "private" {
-  count = local.existing_private_subnets ? 1 : 0
+  count = local.existing_private_subnets ? length(var.subnets["private"]) : 0
   id    = element(var.existing_subnet_ids["private"], count.index)
 }
 
 data "aws_subnet" "database" {
-  count = local.existing_database_subnets ? 1 : 0
+  count = local.existing_database_subnets ? length(var.subnets["database"]) : 0
   id    = element(var.existing_subnet_ids["database"], count.index)
 }
 

--- a/modules/aws_vpc/outputs.tf
+++ b/modules/aws_vpc/outputs.tf
@@ -15,6 +15,12 @@ output "public_subnet_azs" {
   value       = var.vpc_private_enabled ? null : local.existing_public_subnets ? data.aws_subnet.public.*.availability_zone : aws_subnet.public.*.availability_zone
 }
 
+output "public_subnet_cidrs" {
+  description = "CIDR blocks of public subnets"
+  value       = local.existing_public_subnets ? data.aws_subnet.public.*.cidr_block : aws_subnet.public.*.cidr_block
+}
+
+
 output "private_subnets" {
   description = "List of IDs of private subnets"
   value       = local.existing_private_subnets ? data.aws_subnet.private.*.id : aws_subnet.private.*.id
@@ -24,6 +30,12 @@ output "private_subnet_azs" {
   description = "List of private subnet AZs"
   value       = local.existing_private_subnets ? data.aws_subnet.private.*.availability_zone : aws_subnet.private.*.availability_zone
 }
+
+output "private_subnet_cidrs" {
+  description = "CIDR blocks of private subnets"
+  value       = local.existing_private_subnets ? data.aws_subnet.private.*.cidr_block : aws_subnet.private.*.cidr_block
+}
+
 
 output "database_subnets" {
   description = "List of IDs of database subnets"


### PR DESCRIPTION
The primary vpc cidr might not include the subnet cidrs.
And generally,we only need the public and private subnets to access the nfs server anway.
This fix also includes a couple of fixes to byo networking in the aws_vpc module.

Had to change the line endings in the cloud-config file

fixes #90
fixes #93