### PR TITLE
add cluster iam role to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,6 +11,9 @@ output "kube_config" {
 output "worker_iam_role_arn" {
   value = module.eks.worker_iam_role_arn
 }
+output "cluster_iam_role_arn" {
+  value = module.eks.cluster_iam_role_arn
+}
 
 output "rwx_filestore_id" {
   value = var.storage_type == "ha" ? element(coalescelist(aws_efs_file_system.efs-fs.*.id, [""]), 0) : null


### PR DESCRIPTION
simplifies scripting of role updates
example for logging/monitoring:
aws iam attach-role-policy --policy-arn "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" --role-name "$(terraform output -raw cluster_iam_role_arn | cut -d/ -f2)"
aws iam attach-role-policy --policy-arn "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" --role-name "$(terraform output -raw worker_iam_role_arn | cut -d/ -f2)"