### PR TITLE
Fix AWS autoscaler IAM policy condition to match worker tags

### DIFF
--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "worker_autoscaling" {
 
     condition {
       test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${var.cluster_name}"
       values   = ["owned"]
     }
 


### PR DESCRIPTION
Per [AWS CA Prerequisites](https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html#ca-prerequisites) and the [worker_group_default.tags](https://github.com/sassoftware/viya4-iac-aws/blob/main/main.tf#L109) the condition of the CA IAM policy was not matching the applied tags, producing the following error:

```log
failed to delete empty node: failed to delete ip-192-168-xx-xx.ec2.internal: AccessDenied: User: arn:aws:sts::xxxxx:assumed-role/xxx-ns-cluster-autoscaler/xxxxxis not authorized to perform: autoscaling:TerminateInstanceInAutoScalingGroup on resource: arn:aws:autoscaling:us-east-1:xxxx:autoScalingGroup:xxx1f-xxxx-458a-ae1a-0788xxxx84f:autoScalingGroupName/xxx-ns-eks-xxxxx0000001b because no identity-based policy allows the autoscaling:TerminateInstanceInAutoScalingGroup action status code: 403, request id: xxxx-f81b-4078-b14e-xxxx

```