### PR TITLE
support for specifying AZs to use

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,8 @@ locals {
 
   cluster_name                          = "${var.prefix}-eks"
 
+  specific_azs                          = var.azs == null ? data.aws_availability_zones.available.names : var.azs
+
   # Infrastructure Mode
   is_standard                           = var.infra_mode == "standard" ? true : false
   is_private                            = var.infra_mode == "private" ? true : false

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ module "vpc" {
   region              = var.location
   security_group_id   = local.security_group_id
   cidr                = var.vpc_cidr
-  azs                 = data.aws_availability_zones.available.names
+  azs                 = local.specific_azs
   vpc_private_enabled = local.is_private
   existing_subnet_ids = var.subnet_ids
   subnets             = var.subnets

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "location" {
   default     = "us-east-1"
 }
 
+variable "azs" {
+  description = "A list of availability zones names or ids in the region"
+  type = list(string)
+  default = null
+}
+
 variable "aws_profile" {
   description = "Name of Profile in the credentials file"
   type        = string


### PR DESCRIPTION
Users won't always want to use all AZs in a region. This change allows
them to specify the AZs to use.

resolves #113 