### PR TITLE
(IAC-394) [AWS] update viya4-iac-aws from k8s 1.19 to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.1.29
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.19.9
+ARG KUBECTL_VERSION=1.21.2
 
 WORKDIR /viya4-iac-aws
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.1.29
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.21.2
+ARG KUBECTL_VERSION=1.21.7
 
 WORKDIR /viya4-iac-aws
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.21.2
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.21.7
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.1.29
   

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.19.9
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.21.2
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.1.29
   

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -194,7 +194,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | false | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.19" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.21" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.19"
+kubernetes_version                      = "1.21"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.19"
+kubernetes_version                      = "1.21"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -30,7 +30,7 @@ postgres_servers = {
 ssh_public_key                          = "~/.ssh/id_rsa.pub"
 
 ## Cluster config
-kubernetes_version                      = "1.19"
+kubernetes_version                      = "1.21"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags                                    = { } # e.g., { "key1" = "value1", "key2
 # }
 
 ## Cluster config
-kubernetes_version                      = "1.19"
+kubernetes_version                      = "1.21"
 default_nodepool_node_count             = 1
 default_nodepool_vm_type                = "m5.large"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.19"
+kubernetes_version                      = "1.21"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable efs_performance_mode {
 ## Kubernetes
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version"
-  default     = "1.19"
+  default     = "1.21"
 }
 
 variable "tags" {


### PR DESCRIPTION
### Updated viya4-iac-aws from k8s default version from 1.19 to 1.21
### Test Coverage
- Verified using updated Dockerfile, cluster was deployed correctly using K8s v1.21.7 and Viya4 deployment on that cluster was successful