### PR TITLE
(IAC-158) Adding max_prepared_transactions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Create and manage the required cloud resources. Perform one of the following ste
 - run [Terraform](docs/user/TerraformUsage.md) directly on your workstation
 - run the [Docker container](docs/user/DockerUsage.md) (recommended)
 
-### Increase the Max Prepared Transactions in Postgres
+### Increase the Max Prepared Transactions for External Postgres Database
 
 If you are using an external Postgres server, you will need to ensure that the max prepared transactions is at least 1024. You can verify this information by opening the AWS Console and navigating to the RDS Service. Select your Postgres instance, open the Configuration tab, and click on the link to the database's parameter group. Search for the 'max_prepared_transactions' parameter.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Create and manage the required cloud resources. Perform one of the following ste
 - run [Terraform](docs/user/TerraformUsage.md) directly on your workstation
 - run the [Docker container](docs/user/DockerUsage.md) (recommended)
 
+### Increase the Max Prepared Transactions in Postgres
+
+If you are using an external Postgres server, you will need to ensure that the max prepared transactions is at least 1024. You can verify this information by opening the AWS Console and navigating to the RDS Service. Select your Postgres instance, open the Configuration tab, and click on the link to the database's parameter group. Search for the 'max_prepared_transactions' parameter.
+
+If the max prepared transactions is less than 1024, you will need to update the value. Click on the "Edit Parameters" button and change the value to 1024. Once you save your changes, you will need to wait for the database to apply the changes. This can be found back on the configuration tab. After it has been applied, you will need to reboot the database.
+
 ## Troubleshooting
 
 See the [Troubleshooting](./docs/Troubleshooting.md) page for information about possible issues that you might encounter.


### PR DESCRIPTION
Updating the README to include a section about the max_prepared_transactions. This only impacts people who use an external database instead of the internal postgres server. Viya requires the max_prepared_transactions to be at least 1024, but the external AWS postgres database defaults to 0. I included some steps on how to update the values manually.