### PR TITLE
fix typo referencing nfs_private_dns

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -73,7 +73,7 @@ output "nfs_admin_username" {
   value = var.storage_type == "standard" ? module.nfs.0.admin_username : null
 }
 
-output "nsf_private_dns" {
+output "nfs_private_dns" {
   value = var.storage_type == "standard" ? module.nfs.0.private_dns : null
 }
 


### PR DESCRIPTION
this fixes typo in variable `nsf_private_dns` => `nfs_private_dns` in `outputs.tf` 