### PR TITLE
fix: (IAC-634) Pin hashicorp/tls to v3.4.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,28 +6,32 @@ terraform {
       version = "3.72.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "3.1.0"
-    }  
+    }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
       version = "2.1.0"
     }
     null = {
-      source = "hashicorp/null"
+      source  = "hashicorp/null"
       version = "3.1.0"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
       version = "2.2.0"
     }
     external = {
-      source = "hashicorp/external"
+      source  = "hashicorp/external"
       version = "2.1.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = "2.2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.4.0"
     }
   }
 }


### PR DESCRIPTION
## Change
Pin hashicorp/tls to v3.4.0 to work around this issue: https://issuemode.com/issues/hashicorp/terraform-provider-tls/109418411

## Tests
More details in internal ticket.
After pinning the version, I was able to successfully create the infrastructure in AWS as well as perform a Viya deployment in the cluster. 
