### PR TITLE
fix: (IAC-632) tfvars PREFIX not applied to host nodes for k8s/Viya

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -74,7 +74,7 @@ locals {
   user_node_pool = {
     for key, np_value in var.node_pools :
       key => {
-        name                            = key
+        name                            = "${local.cluster_name}-${key}"
         instance_types                  = [np_value.vm_type]
         ami_type                        = np_value.cpu_type
         disk_size                       = np_value.os_disk_size

--- a/locals.tf
+++ b/locals.tf
@@ -33,7 +33,7 @@ locals {
   # Mapping node_pools to node_groups
   default_node_pool = {
     default = {
-      name                              = "default"
+      name                              = "${local.cluster_name}-default"
       instance_types                     = [var.default_nodepool_vm_type]
       block_device_mappings           = {
         xvda = {


### PR DESCRIPTION
# Changes:
Updated the code to include the `<prefix>-eks-<node_name>` to show up for the node names.

# Test
Verified the changes by creating cluster, instance names for the nodes were populated with prefix. See internal ticket for details.