### PR TITLE
feat: (IAC-544) AWS - support for k8s 1.23 and dropping 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.1.29
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.21.7
+ARG KUBECTL_VERSION=1.22.10
 
 WORKDIR /viya4-iac-aws
 
@@ -17,7 +17,7 @@ RUN yum -y install git openssh jq which \
   && chmod g=u -R /etc/passwd /etc/group /viya4-iac-aws \
   && git config --system --add safe.directory /viya4-iac-aws \
   && terraform init
-  
+
 ENV TF_VAR_iac_tooling=docker
 ENTRYPOINT ["/viya4-iac-aws/docker-entrypoint.sh"]
 VOLUME ["/workspace"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project contains Terraform scripts to provision the AWS cloud infrastructur
 This project helps you to automate the cluster-provisioning phase of SAS Viya deployment. To learn about all phases and options of the
 SAS Viya deployment process, see [Getting Started with SAS Viya and Azure Kubernetes Service](https://go.documentation.sas.com/doc/en/itopscdc/default/itopscon/n1d7qc4nfr3s5zn103a1qy0kj4l1.htm) in _SAS&reg; Viya&reg; Operations_.
 
-Once the cloud resources are provisioned, use the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) project to deploy 
+Once the cloud resources are provisioned, use the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) project to deploy
 SAS Viya 4 in your cloud environment. For more information about SAS Viya 4 requirements and documentation for the deployment
 process, refer to the [SAS Viya 4 Operations Guide](https://go.documentation.sas.com/doc/en/itopscdc/default/itopswlcm/home.htm).
 
@@ -35,22 +35,22 @@ Use of these tools requires operational knowledge of the following technologies:
 This project supports two options for running Terraform scripts:
 - Terraform installed on your local machine
 - Using a Docker container to run Terraform (Docker is required)
-  
+
   For more information, see [Docker Usage](./docs/user/DockerUsage.md). Using Docker to run the Terraform scripts is recommended.
-  
+
 The following are also required:
 - Access to an **AWS account** with a user that is associated with the applied [IAM Policy](./files/policies/devops-iac-eks-policy.json)
 - Subscription to [Ubuntu 20.04 LTS - Focal](https://aws.amazon.com/marketplace/pp/prodview-iftkyuwv2sjxi)
-  
+
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.21.7
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.22.10
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.1.29
-  
+
 #### Docker Requirements:
-  
+
 - [Docker](https://docs.docker.com/get-docker/)
 
 ## Getting Started
@@ -75,12 +75,12 @@ In order to create and destroy AWS resources on your behalf, Terraform needs an 
 ### Customize Input Values
 
 Terraform scripts require variable definitions as input. Review and modify default values to meet your requirements. Create a file named
-`terraform.tfvars` to customize any input variable value documented in the [CONFIG-VARS.md](docs/CONFIG-VARS.md) file. 
+`terraform.tfvars` to customize any input variable value documented in the [CONFIG-VARS.md](docs/CONFIG-VARS.md) file.
 
 To get started, you can copy one of the example variable definition files provided in the [examples](./examples) folder. For more information about the
 variables that are declared in each file, refer to the [CONFIG-VARS.md](docs/CONFIG-VARS.md) file.
 
-**NOTE:** You will need to update the `cidr_blocks` in the [variables.tf](variables.tf) file to allow traffic from your current network. Without these rules, 
+**NOTE:** You will need to update the `cidr_blocks` in the [variables.tf](variables.tf) file to allow traffic from your current network. Without these rules,
 access to the cluster will only be allowed via the AWS Console.
 
 You have the option to specify variable definitions that are not included in `terraform.tfvars` or to use a variable definition file other than
@@ -88,7 +88,7 @@ You have the option to specify variable definitions that are not included in `te
 
 ## Create and Manage Cloud Resources
 
-Create and manage the required cloud resources. Perform one of the following steps, based on whether you are using Docker: 
+Create and manage the required cloud resources. Perform one of the following steps, based on whether you are using Docker:
 
 - run [Terraform](docs/user/TerraformUsage.md) directly on your workstation
 - run the [Docker container](docs/user/DockerUsage.md) (recommended)

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -197,7 +197,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | false | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.22.10" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.22" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -197,7 +197,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | false | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.21" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.22.10" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -1,5 +1,5 @@
 # !NOTE! - These are only a subset of the variables in CONFIG-VARS.md provided
-# as examples. Customize this file to add any variables from CONFIG-VARS.md whose 
+# as examples. Customize this file to add any variables from CONFIG-VARS.md whose
 # default values you want to change.
 
 # ****************  REQUIRED VARIABLES  ****************
@@ -13,7 +13,7 @@ vpc_id  = "<existing-vpc-id>" # only needed if using pre-existing VPC
 subnet_ids = {  # only needed if using pre-existing subnets
   "public" : ["existing-public-subnet-id1", "existing-public-subnet-id2"],
   "private" : ["existing-private-subnet-id1", "existing-private-subnet-id2"],
-  "database" : ["existing-database-subnet-id1", "existing-database-subnet-id2"] # only when 'create_postgres=true' 
+  "database" : ["existing-database-subnet-id1", "existing-database-subnet-id2"] # only when 'create_postgres=true'
 }
 nat_id = "<existing-NAT-gateway-id>"
 security_group_id = "<existing-security-group-id>" # only needed if using pre-existing Security Group
@@ -37,12 +37,12 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,12 +27,12 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,18 +27,18 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 
 ## Cluster Node Pools config
 node_pools = {
-  cas = { 
+  cas = {
     "vm_type" = "i3.8xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -47,15 +47,15 @@ node_pools = {
     "min_nodes" = 1
     "max_nodes" = 5
     "node_taints" = ["workload.sas.com/class=cas:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "cas" 
+    "node_labels" = {
+      "workload.sas.com/class" = "cas"
     }
     "custom_data" = "./files/custom-data/additional_userdata.sh"
     "metadata_http_endpoint"               = "enabled"
     "metadata_http_tokens"                 = "required"
     "metadata_http_put_response_hop_limit" = 1
   },
-  compute = { 
+  compute = {
     "vm_type" = "m5.8xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -73,7 +73,7 @@ node_pools = {
     "metadata_http_tokens"                 = "required"
     "metadata_http_put_response_hop_limit" = 1
   },
-  stateless = { 
+  stateless = {
     "vm_type" = "m5.4xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -82,15 +82,15 @@ node_pools = {
     "min_nodes" = 1
     "max_nodes" = 5
     "node_taints" = ["workload.sas.com/class=stateless:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "stateless" 
+    "node_labels" = {
+      "workload.sas.com/class" = "stateless"
     }
     "custom_data" = ""
     "metadata_http_endpoint"               = "enabled"
     "metadata_http_tokens"                 = "required"
     "metadata_http_put_response_hop_limit" = 1
-  },   
-  stateful = { 
+  },
+  stateful = {
     "vm_type" = "m5.4xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -99,8 +99,8 @@ node_pools = {
     "min_nodes" = 1
     "max_nodes" = 3
     "node_taints" = ["workload.sas.com/class=stateful:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "stateful" 
+    "node_labels" = {
+      "workload.sas.com/class" = "stateful"
     }
     "custom_data" = ""
     "metadata_http_endpoint"               = "enabled"

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,12 +27,12 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -30,18 +30,18 @@ postgres_servers = {
 ssh_public_key                          = "~/.ssh/id_rsa.pub"
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "ha"
 
 ## Cluster Node Pools config
 node_pools = {
-  cas = { 
+  cas = {
     "vm_type" = "i3.8xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -50,15 +50,15 @@ node_pools = {
     "min_nodes" = 1
     "max_nodes" = 5
     "node_taints" = ["workload.sas.com/class=cas:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "cas" 
+    "node_labels" = {
+      "workload.sas.com/class" = "cas"
     }
     "custom_data" = "./files/custom-data/additional_userdata.sh"
     "metadata_http_endpoint"               = "enabled"
     "metadata_http_tokens"                 = "required"
     "metadata_http_put_response_hop_limit" = 1
   },
-  compute = { 
+  compute = {
     "vm_type" = "m5.8xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -76,7 +76,7 @@ node_pools = {
     "metadata_http_tokens"                 = "required"
     "metadata_http_put_response_hop_limit" = 1
   },
-  stateless = { 
+  stateless = {
     "vm_type" = "m5.4xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -85,15 +85,15 @@ node_pools = {
     "min_nodes" = 1
     "max_nodes" = 5
     "node_taints" = ["workload.sas.com/class=stateless:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "stateless" 
+    "node_labels" = {
+      "workload.sas.com/class" = "stateless"
     }
     "custom_data" = ""
     "metadata_http_endpoint"               = "enabled"
     "metadata_http_tokens"                 = "required"
     "metadata_http_put_response_hop_limit" = 1
-  },   
-  stateful = { 
+  },
+  stateful = {
     "vm_type" = "m5.4xlarge"
     "cpu_type" = "AL2_x86_64"
     "os_disk_type" = "gp2"
@@ -102,8 +102,8 @@ node_pools = {
     "min_nodes" = 1
     "max_nodes" = 3
     "node_taints" = ["workload.sas.com/class=stateful:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "stateful" 
+    "node_labels" = {
+      "workload.sas.com/class" = "stateful"
     }
     "custom_data" = ""
     "metadata_http_endpoint"               = "enabled"

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -30,7 +30,7 @@ postgres_servers = {
 ssh_public_key                          = "~/.ssh/id_rsa.pub"
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,12 +27,12 @@ tags                                    = { } # e.g., { "key1" = "value1", "key2
 # }
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 1
 default_nodepool_vm_type                = "m5.large"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 
@@ -48,8 +48,8 @@ node_pools = {
     "min_nodes"          = 0
     "max_nodes"          = 5
     "node_taints"        = ["workload.sas.com/class=cas:NoSchedule"]
-    "node_labels" = { 
-      "workload.sas.com/class" = "cas" 
+    "node_labels" = {
+      "workload.sas.com/class" = "cas"
     }
     "custom_data" = ""
     "metadata_http_endpoint"               = "enabled"

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags                                    = { } # e.g., { "key1" = "value1", "key2
 # }
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 1
 default_nodepool_vm_type                = "m5.large"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22.10"
+kubernetes_version                      = "1.22"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,12 +27,12 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.21"
+kubernetes_version                      = "1.22.10"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""
 
-## General 
+## General
 efs_performance_mode                    = "maxIO"
 storage_type                            = "standard"
 

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable efs_performance_mode {
 ## Kubernetes
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version"
-  default     = "1.22.10"
+  default     = "1.22"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "postgres_public_access_cidrs" {
   default     = null
 }
 
-## Provider Specific 
+## Provider Specific
 variable "ssh_public_key" {
   description = "SSH public key used to access VMs"
   default = "~/.ssh/id_rsa.pub"
@@ -95,7 +95,7 @@ variable efs_performance_mode {
 ## Kubernetes
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version"
-  default     = "1.21"
+  default     = "1.22.10"
 }
 
 variable "tags" {
@@ -285,7 +285,7 @@ variable "subnet_ids" {
   # subnet_ids = {  # only needed if using pre-existing subnets
   #   "public" : ["existing-public-subnet-id1", "existing-public-subnet-id2"],
   #   "private" : ["existing-private-subnet-id1", "existing-private-subnet-id2"],
-  #   "database" : ["existing-database-subnet-id1", "existing-database-subnet-id2"] # only when 'create_postgres=true' 
+  #   "database" : ["existing-database-subnet-id1", "existing-database-subnet-id2"] # only when 'create_postgres=true'
   # }
 }
 
@@ -302,13 +302,13 @@ variable subnets {
     "public" : ["192.168.129.0/25", "192.168.129.128/25"],
     "database" : ["192.168.128.0/25", "192.168.128.128/25"]
     }
-} 
+}
 
 variable "security_group_id" {
   type    = string
   default = null
   description = "Pre-existing Security Group id. Leave blank to have one created"
-  
+
 }
 
 variable "cluster_security_group_id" {
@@ -477,7 +477,7 @@ variable "postgres_servers" {
       for k,v in var.postgres_servers : contains(keys(v),"administrator_password") ? alltrue([
         length(v.administrator_password) > 7,
         can(regex("^[^/'\"@]+$", v.administrator_password)),
-      ]) : true 
+      ]) : true
     ]) : false : true
     error_message = "ERROR: The admin passsword must have more than 8 characters, and be composed of any printable characters except the following / ' \" @ characters."
   }


### PR DESCRIPTION
## Changes
Update the kubectl version being used to 1.22.10 and the k8s version in the sample input files to v1.22. Updated README and CONFIG-VARS doc.
## Tests
See internal ticket for details and test artifacts
1. Used updated docker image to create clusters at 1.21, 1.22 and 1.23 K8s versions with successful deployments.
2. The updated kubectl version is now at 1.22.10 in the container