### PR TITLE
fix: (IAC-700) change to pre_bootstrap_user_data for node pools

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -57,7 +57,7 @@ locals {
       labels                            = var.default_nodepool_labels
       # User data
       bootstrap_extra_args              = "--kubelet-extra-args '--node-labels=${replace(replace(jsonencode(var.default_nodepool_labels), "/[\"\\{\\}]/", ""), ":", "=")} --register-with-taints=${join(",", var.default_nodepool_taints)} ' "
-      post_bootstrap_user_data          = (var.default_nodepool_custom_data != "" ? file(var.default_nodepool_custom_data) : "")
+      pre_bootstrap_user_data          = (var.default_nodepool_custom_data != "" ? file(var.default_nodepool_custom_data) : "")
       metadata_options                  = { 
           http_endpoint                 = var.default_nodepool_metadata_http_endpoint
           http_tokens                   = var.default_nodepool_metadata_http_tokens
@@ -101,7 +101,7 @@ locals {
         labels                          = np_value.node_labels
         # User data
         bootstrap_extra_args            = "--kubelet-extra-args '--node-labels=${replace(replace(jsonencode(np_value.node_labels), "/[\"\\{\\}]/", ""), ":", "=")} --register-with-taints=${join(",", np_value.node_taints)}' "
-        post_bootstrap_user_data        = (np_value.custom_data != "" ? file(np_value.custom_data) : "")
+        pre_bootstrap_user_data        = (np_value.custom_data != "" ? file(np_value.custom_data) : "")
         metadata_options                = { 
             http_endpoint               = var.default_nodepool_metadata_http_endpoint
             http_tokens                 = var.default_nodepool_metadata_http_tokens


### PR DESCRIPTION
### Changes
Updates the node pool maps (default and user defined) in `locals.tf` to use `pre_bootstrap_user_data` rather than post so that the init script get run. The reason why pre needs to be used rather than post is because we do not specify a value for `ami_id`. See doc from AWS:
https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/user_data.md#eks-managed-node-group


### Test Scenario
- Created a minimal .tfvars file that has a default and cas node pool.

Snippet:
```
# this is a truncated example 
## Cluster config
kubernetes_version                      = "1.22"
default_nodepool_node_count             = 2
default_nodepool_vm_type                = "i3.8xlarge"
default_nodepool_custom_data            = "./files/custom-data/additional_userdata.sh"
node_pools = {
  cas = {
    "vm_type" = "i3.8xlarge"
    "cpu_type"     = "AL2_x86_64"
    "os_disk_type" = "gp2"
    "os_disk_size" = 200
    "os_disk_iops" = 0
    "min_nodes" = 1
    "max_nodes" = 1
    "node_taints" = ["workload.sas.com/class=cas:NoSchedule"]
    "node_labels" = {
      "workload.sas.com/class" = "cas"
    }
    "custom_data" = "./files/custom-data/additional_userdata.sh"
    "metadata_http_endpoint"               = "enabled"
    "metadata_http_tokens"                 = "required"
    "metadata_http_put_response_hop_limit" = 1
  }
}
```
- Both have "vm_type" = "i3.8xlarge" so that the instance comes with 4x1900 NVMe SSD for testing out `additional_userdata.sh` init script that will set up RAID0.
- `custom_data` & `default_nodepool_custom_data` are defined so that `additional_userdata.sh` will be used as the init script for the instances 

- After creation, in the AWS console, verified the launch templates `$prefix-eks-default-lt-2022091519082919750000000e` and `$prefix-eks-cas-lt-20220915190829201500000010` had user data that matches the content of `additional_userdata.sh`
- SSHed into the nodes to verify that init script was run by checking the `cloud-init-output.log` as well as running `mdadm --detail /dev/md0` to verify RAID0 was running.

Additional details and test artifacts are included in the internal ticket.
