### PR TITLE
feat: (IAC-704) Update default postgresSQL server_version to v13

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -298,7 +298,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 <!--| Name | Description | Type | Default | Notes | -->
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
-| server_version | The version of the PostgreSQL server | string | "11" | Changing this value trigger resource recreation |
+| server_version | The version of the PostgreSQL server | string | "13" | Supported values are 11-14. Changing this value triggers resource recreation. |
 | instance_type | The VM type for the PostgreSQL Server | string | "db.m5.xlarge" | |
 | storage_size | Max storage allowed for the PostgreSQL server in MB | number | 50 |  |
 | backup_retention_days | Backup retention days for the PostgreSQL server | number | 7 | Supported values are between 7 and 35 days. |
@@ -328,7 +328,7 @@ database_servers = {
     deletion_protection          = false
     administrator_login          = "cpsadmin"
     administrator_password       = "1tsAB3aut1fulDay"
-    server_version               = "12"
+    server_version               = "13"
     server_port                  = "5432"
     ssl_enforcement_enabled      = true
     parameters                   = [{ "apply_method": "immediate", "name": "foo" "value": "true" }, { "apply_method": "immediate", "name": "bar" "value": "false" }]

--- a/variables.tf
+++ b/variables.tf
@@ -426,7 +426,7 @@ variable "postgres_server_defaults" {
     deletion_protection          = false
     administrator_login          = "pgadmin"
     administrator_password       = "my$up3rS3cretPassw0rd"
-    server_version               = "11"
+    server_version               = "13"
     server_port                  = "5432"
     ssl_enforcement_enabled      = true
     parameters                   = []


### PR DESCRIPTION
### Changes
Changes the default value for the `server_version` variable located within the `postgres_server_defaults` map to 13.
The user can specify any postgres version from 11 to 14.

### Testing
Executed the following development test scenarios for each postgres version:

|PostgresSQL version scenario|Provider|K8s version|Cadence|Stable Deployment|input.tfvars server_version|RDS Installed (via TF) External Postgres version|
|---|---|---|---|---|---|---|
|PostgresSQL v11|AWS|1.23|fast:2020|Yes|11|db engine 11.16 (postgres 11.16 was installed with the current default of "11" in variables.tf)|
|v12|AWS|v1.22.11-eks|fast:2020|Yes|12|db engine 12.11|
|v13|AWS|v1.22.12-eks|fast:2020|Yes|left unspecified, 13 is the new default in variables.tf|db engine 13.7|
|v14|AWS|v1.22.12-eks|fast:2020|Yes|14|db engine 14.3|