### PR TITLE
feat: (IAC-731) Back down the Postgres version to v12

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -298,7 +298,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 <!--| Name | Description | Type | Default | Notes | -->
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
-| server_version | The version of the PostgreSQL server | string | "13" | Refer to the [Viya 4 Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for SAS Viya. |
+| server_version | The version of the PostgreSQL server | string | "12" | Refer to the [Viya 4 Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for SAS Viya. |
 | instance_type | The VM type for the PostgreSQL Server | string | "db.m5.xlarge" | |
 | storage_size | Max storage allowed for the PostgreSQL server in MB | number | 50 |  |
 | backup_retention_days | Backup retention days for the PostgreSQL server | number | 7 | Supported values are between 7 and 35 days. |
@@ -328,7 +328,7 @@ database_servers = {
     deletion_protection          = false
     administrator_login          = "cpsadmin"
     administrator_password       = "1tsAB3aut1fulDay"
-    server_version               = "13"
+    server_version               = "12"
     server_port                  = "5432"
     ssl_enforcement_enabled      = true
     parameters                   = [{ "apply_method": "immediate", "name": "foo" "value": "true" }, { "apply_method": "immediate", "name": "bar" "value": "false" }]

--- a/variables.tf
+++ b/variables.tf
@@ -426,7 +426,7 @@ variable "postgres_server_defaults" {
     deletion_protection          = false
     administrator_login          = "pgadmin"
     administrator_password       = "my$up3rS3cretPassw0rd"
-    server_version               = "13"
+    server_version               = "12"
     server_port                  = "5432"
     ssl_enforcement_enabled      = true
     parameters                   = []


### PR DESCRIPTION
# Changes:
Back down the Postgres version to v12 while waiting for 2022.10

# Test:
Verified default version is set to 12