### PR TITLE
(IAC_733)AWS - failed to create sas_iac_buildinfo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -190,7 +190,7 @@ module "kubeconfig" {
   endpoint                 = module.eks.cluster_endpoint
   ca_crt                   = local.kubeconfig_ca_cert
 
-  depends_on = [ module.eks ]
+  depends_on = [module.eks.cluster_id] # The name/id of the EKS cluster. Will block on cluster creation until the cluster is really ready.
 }
 
 # Database Setup - https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/3.3.0


### PR DESCRIPTION
<h2 dir="auto">Changes</h2>
<p dir="auto">Modified the root main.tf; module.kubeconfig depends_on reference - to deal with the sas_iac_buildinfo creation/timeout failures.
</p>

<h2 dir="auto">Test</h2>
<p dir="auto">
See internal ticket for details and test artifacts:
</p>
<ol dir="auto">
<li>Used updated docker image and sample tfvars files to create sas_iac_buildinfo with success.</li>
</ol>