### PR TITLE
feat: (IAC-655) EKS Add Support for K8s 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.7.22
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.22.10
+ARG KUBECTL_VERSION=1.23.8
 
 WORKDIR /viya4-iac-aws
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.22.10
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.23.8
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.7.22
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -196,7 +196,7 @@ Custom policy:
 
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
-| create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | false | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
+| create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | true | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
 | kubernetes_version | The EKS cluster Kubernetes version | string | "1.23" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -197,7 +197,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | false | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.22" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.23" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -30,7 +30,7 @@ postgres_servers = {
 ssh_public_key                          = "~/.ssh/id_rsa.pub"
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags                                    = { } # e.g., { "key1" = "value1", "key2
 # }
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 1
 default_nodepool_vm_type                = "m5.large"
 default_nodepool_custom_data            = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version                      = "1.22"
+kubernetes_version                      = "1.23"
 default_nodepool_node_count             = 2
 default_nodepool_vm_type                = "m5.2xlarge"
 default_nodepool_custom_data            = ""

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -21,9 +21,10 @@ data "template_file" "kubeconfig_provider" {
 data "kubernetes_secret" "sa_secret" {
   count = var.create_static_kubeconfig ? 1 : 0
   metadata {
-    name      = kubernetes_service_account.kubernetes_sa.0.default_secret_name
+    name      = kubernetes_secret.sa_secret.0.metadata.0.name
     namespace = var.namespace
   }
+  depends_on = [kubernetes_secret.sa_secret]
 }
 
 data "template_file" "kubeconfig_sa" {
@@ -38,8 +39,25 @@ data "template_file" "kubeconfig_sa" {
     token        = lookup(data.kubernetes_secret.sa_secret.0.data,"token", "")
     namespace    = var.namespace
   }
+  depends_on = [data.kubernetes_secret.sa_secret]
 }
 
+# 1.24 change: Create service account secret
+resource "kubernetes_secret" "sa_secret" {
+  count = var.create_static_kubeconfig ? 1 : 0
+  metadata {
+    name      = local.service_account_secret_name
+    namespace = var.namespace
+    annotations = {
+      "kubernetes.io/service-account.name" = local.service_account_name
+    }
+  }
+  type = "kubernetes.io/service-account-token"
+  depends_on = [kubernetes_service_account.kubernetes_sa]
+}
+
+# Starting K8s v1.24+ hashicorp/terraform-provider-kubernetes issues warning message:
+# "Warning: 'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above"
 resource "kubernetes_service_account" "kubernetes_sa" {
   count = var.create_static_kubeconfig ? 1 : 0
   metadata {

--- a/modules/kubeconfig/templates/kubeconfig-provider.tmpl
+++ b/modules/kubeconfig/templates/kubeconfig-provider.tmpl
@@ -16,7 +16,7 @@ users:
 - name: ${cluster_name}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - ${region}

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable efs_performance_mode {
 ## Kubernetes
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version"
-  default     = "1.22"
+  default     = "1.23"
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -27,7 +27,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.12.0"
+      version = "2.13.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Background:
Starting from Kubernetes version `1.24.0` service account token is not automatically generated, thus it has to be created separately. The following resources were updated by the provider `hashicorp/kubernetes` to handle this change in `v2.13.0`: `d/kubernetes_service_account`, `r/kubernetes_default_service_account`, `r/kubernetes_service_account`. For Kubernetes clusters running v1.24+ `default_secret_name` will be empty. A warning message will be printed once any of the above resources are in use. 

## Changes
* To support 1.24+ Kubernetes version in EKS, a secret is manually created for the service account
* The default K8s value is updated from 1.22 to 1.23
* The default kubectl value is updated from 1.22.10 to 1.23.8
* Updated `hashicorp/kubernetes` to 2.13.0
* An update was made to kubeconfig-provider.tmpl to change the apiVersion to `client.authentication.k8s.io/v1beta1` since `client.authentication.k8s.io/v1alpha1` has been deprecated
  * See https://github.com/aws/aws-cli/issues/6920

## Tests

1. Created a 1.24 cluster with the updated code and successfully deployed Viya
1. Created a 1.23 cluster with the updated code and successfully deployed Viya
1. Created a 1.22 cluster with the updated code and successfully deployed Viya
1. Created a 1.24 cluster with create_static_kubeconfig=false and verified that the code workflow to create a provider based kubeconfig was not modified. I was able to use the provider based kubeconfig to view cluster resources.
