### PR TITLE
docs: (IAC-864) Update SAS Viya name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 ## Overview
 
-This project contains Terraform scripts to provision the AWS cloud infrastructure resources that are required to deploy SAS Viya 4 product offerings. Here is a list of resources that this project can create:
+This project contains Terraform scripts to provision the AWS cloud infrastructure resources that are required to deploy SAS Viya platform product offerings. Here is a list of resources that this project can create:
 
   >- Amazon VPC and Security Group
   >- Managed Amazon Elastic Kubernetes Service (EKS)
   >- Amazon EKS managed node groups with required labels and taints
-  >- Infrastructure to deploy the SAS Viya CAS server in SMP or MPP mode
+  >- Infrastructure to deploy the SAS Viya platform CAS server in SMP or MPP mode
   >- Amazon Elastic Block Storage (EBS) for NFS
   >- Amazon Elastic File System (EFS)
   >- Amazon Relational Database Service (RDS)
 
 [<img src="./docs/images/viya4-iac-aws-diag.png" alt="Architecture Diagram" width="750"/>](./docs/images/viya4-iac-aws-diag.png?raw=true)
 
-This project helps you to automate the cluster-provisioning phase of SAS Viya deployment. To learn about all phases and options of the
-SAS Viya deployment process, see [Getting Started with SAS Viya and Azure Kubernetes Service](https://go.documentation.sas.com/doc/en/itopscdc/default/itopscon/n1d7qc4nfr3s5zn103a1qy0kj4l1.htm) in _SAS&reg; Viya&reg; Operations_.
+This project helps you to automate the cluster-provisioning phase of SAS Viya platform deployment. To learn about all phases and options of the
+SAS Viya platform deployment process, see [Getting Started with SAS Viya and Azure Kubernetes Service](https://go.documentation.sas.com/doc/en/itopscdc/default/itopscon/n1d7qc4nfr3s5zn103a1qy0kj4l1.htm) in _SAS&reg; Viya&reg; Platform Operations_.
 
 Once the cloud resources are provisioned, use the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) project to deploy
-SAS Viya 4 in your cloud environment. For more information about SAS Viya 4 requirements and documentation for the deployment
-process, refer to the [SAS Viya 4 Operations Guide](https://go.documentation.sas.com/doc/en/itopscdc/default/itopswlcm/home.htm).
+the SAS Viya platform in your cloud environment. For more information about SAS Viya platform requirements and documentation for the deployment
+process, refer to the [SAS Viya platform Operations Guide](https://go.documentation.sas.com/doc/en/itopscdc/default/itopswlcm/home.htm).
 
 ## Prerequisites
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -298,7 +298,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 <!--| Name | Description | Type | Default | Notes | -->
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
-| server_version | The version of the PostgreSQL server | string | "13" | Refer to the [Viya 4 Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for SAS Viya. |
+| server_version | The version of the PostgreSQL server | string | "13" | Refer to the [SAS Viya platform Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | instance_type | The VM type for the PostgreSQL Server | string | "db.m5.xlarge" | |
 | storage_size | Max storage allowed for the PostgreSQL server in MB | number | 50 |  |
 | backup_retention_days | Backup retention days for the PostgreSQL server | number | 7 | Supported values are between 7 and 35 days. |

--- a/docs/sas-updates.md
+++ b/docs/sas-updates.md
@@ -1,10 +1,10 @@
-New in SAS Viya 2021.2.6: the connect workload class is no longer required. For more information, see [Connect Workload Class Changes](https://go.documentation.sas.com/doc/en/itopscdc/v_026/itopswn/n0jh2fbifqgoksn1uou9p2zgbzdy.htm#p15778dvqwzjtgn1e95nq9v0y1wv).
+New in SAS Viya platform 2021.2.6: the connect workload class is no longer required. For more information, see [Connect Workload Class Changes](https://go.documentation.sas.com/doc/en/itopscdc/v_026/itopswn/n0jh2fbifqgoksn1uou9p2zgbzdy.htm#p15778dvqwzjtgn1e95nq9v0y1wv).
  
-To deploy SAS Viya 2021.2.6 and later, use the most recent version of SAS Viya 4 Infrastructure as Code. The default settings do not create a connect node pool. If your current software order has a requirement for the connect node pool, you can use the connect node pool example file in `examples/sample-input-connect.tfvars`.
+To deploy the SAS Viya platform 2021.2.6 and later, use the most recent version of SAS Viya 4 Infrastructure as Code. The default settings do not create a connect node pool. If your current software order has a requirement for the connect node pool, you can use the connect node pool example file in `examples/sample-input-connect.tfvars`.
  
-If you are updating SAS Viya to version 2021.2.6, take some additional steps to remove the connect nodes.
+If you are updating the SAS Viya platform to version 2021.2.6, take some additional steps to remove the connect nodes.
 
-1.	Perform the update by following the steps in the [SAS Viya documentation](https://go.documentation.sas.com/doc/en/itopscdc/default/k8sag/p043aa4ghwwom6n1beyfifdgkve7.htm). 
+1.	Perform the update by following the steps in the [SAS Viya platform documentation](https://go.documentation.sas.com/doc/en/itopscdc/default/k8sag/p043aa4ghwwom6n1beyfifdgkve7.htm). 
 2.	When the update to 2021.2.6 has completed successfully, edit the sample-input-*.tfvars to scale down the connect node pool. Change `min_nodes` and `max_nodes` to 0:
 ```
   connect = {

--- a/docs/user/AdvancedTerraformUsage.md
+++ b/docs/user/AdvancedTerraformUsage.md
@@ -38,7 +38,7 @@ After the resources have been created, use ```terraform state list``` to list al
     # to get more details on a particular resource 
     terraform state show <resource-name-from-state-list>
 
-If you decide to use the [viya4-deployment project](https://github.com/sassoftware/viya4-deployment), which uses Ansible to complete the configuration of your cluster to meet SAS Viya requirements, you can provide the tfstate file to enable auto-discovery of the kubeconfig file and other settings.
+If you decide to use the [viya4-deployment project](https://github.com/sassoftware/viya4-deployment), which uses Ansible to complete the configuration of your cluster to meet SAS Viya platform requirements, you can provide the tfstate file to enable auto-discovery of the kubeconfig file and other settings.
 
 ## Terraform - Output
 


### PR DESCRIPTION
### Changes
Updating the SAS Viya name in the documentation

### Note: 

The repo's "About" section will also need to change as part of this PR, since that's not controlled by the code I'll put the updated content here. Please review this as well.


>This project contains Terraform configuration files to provision infrastructure components required to deploy SAS Viya platform products products on Amazon AWS.
