### PR TITLE
Change S3 Private Endpoint to Gateway type

### DIFF
--- a/modules/aws_vpc/main.tf
+++ b/modules/aws_vpc/main.tf
@@ -53,6 +53,21 @@ resource "aws_vpc_endpoint" "private_endpoints" {
   ]
 }
 
+resource "aws_vpc_endpoint" "s3_private_endpoint" {
+  vpc_id             = local.vpc_id
+  service_name       = "com.amazonaws.${var.region}.${var.vpc_s3_private_endpoint}"
+  vpc_endpoint_type  = "Gateway"
+
+  tags = merge(
+    {
+      "Name" = format("%s", "${var.name}-private-endpoint-${var.vpc_s3_private_endpoint}")
+    },
+    var.tags,
+  )
+
+  route_table_ids = aws_route_table.private.*.id
+}
+
 data "aws_subnet" "public" {
   count = local.existing_public_subnets ? length(var.subnets["public"]) : 0
   id    = element(var.existing_subnet_ids["public"], count.index)

--- a/modules/aws_vpc/variables.tf
+++ b/modules/aws_vpc/variables.tf
@@ -106,7 +106,13 @@ variable "map_public_ip_on_launch" {
 variable "vpc_private_endpoints" {
    description = "Endpoints needed for private cluster"
    type        = list(string)
-   default     = [ "ec2", "ecr.api", "ecr.dkr", "s3", "logs", "sts", "elasticloadbalancing", "autoscaling" ]
+   default     = [ "ec2", "ecr.api", "ecr.dkr", "logs", "sts", "elasticloadbalancing", "autoscaling" ]
+}
+
+variable "vpc_s3_private_endpoint" {
+   description = "S3 gateway endpoint needed for private cluster"
+   type        = string
+   default     = "s3"
 }
 
 variable "region" {


### PR DESCRIPTION
Proposed change to switch the s3 private endpoint type from interface to gateway for private air-gap/darksite EKS installs.

Fixes #180 