### PR TITLE
feat: (IAC-903): add K8s 1.25 support, set kubectl default to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.7.22
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.24.8
+ARG KUBECTL_VERSION=1.24.10
 
 WORKDIR /viya4-iac-aws
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.7.22
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.23.8
+ARG KUBECTL_VERSION=1.24.8
 
 WORKDIR /viya4-iac-aws
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.23.8
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.24.8
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.7.22
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.24.8
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.24.10
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.7.22
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -197,7 +197,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | true | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.23" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.24" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 1
 default_nodepool_vm_type     = "m5.large"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.23"
+kubernetes_version           = "1.24"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "worker_autoscaling" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
       "ec2:DescribeImages",
       "ec2:GetInstanceTypesFromInstanceRequirements",
       "eks:DescribeNodegroup"

--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -1,3 +1,5 @@
+# Permissions based off the IAM Policy recommended by kubernetes/autoscaler
+# https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.25.0/cluster-autoscaler/cloudprovider/aws/README.md
 data "aws_iam_policy_document" "worker_autoscaling" {
   statement {
     sid    = "eksWorkerAutoscalingAll"
@@ -7,7 +9,9 @@ data "aws_iam_policy_document" "worker_autoscaling" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
       "autoscaling:DescribeTags",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
     ]
 
@@ -21,7 +25,9 @@ data "aws_iam_policy_document" "worker_autoscaling" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
 
     resources = ["*"]

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "efs_performance_mode" {
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version."
   type        = string
-  default     = "1.23"
+  default     = "1.24"
 }
 
 variable "tags" {


### PR DESCRIPTION
### Changes

Since the SAS Viya Platform will be supporting K8s 1.23, 1.24, and 1.25 in March as part of the 2023.03 cadence, the kubectl and cluster_version version is being changed to 1.24.10 so that it's within the +/- 1 range of the supported versions. 

This PR also includes an update to the policy to add support for the new default `CLUSTER_AUTOSCALER_CHART_VERSION` (9.25.0) used for K8s 1.25+ clusters in viya4-deployment. This policy update was additive so `CLUSTER_AUTOSCALER_CHART_VERSION` (9.9.2) that is being used for <1.25 clusters still functions.

The PR where the `CLUSTER_AUTOSCALER_CHART_VERSION`  update was made is https://github.com/sassoftware/viya4-deployment/pull/399 and will be released as part of viya4-deployment:6.3.0. In case a user uses version 5.5.0 of viya4-iac-aws or earlier to create their K8s 1.25 infrastructure in AWS (which would not include the Role policy updates), the troubleshooting documentation in viya4-deployment has steps remediate this by either using the latest version of viya4-iac-aws to update the Role policy or manual steps the user can take in the AWS IAM Console to achieve the same.

### Tests

Tested the following scenarios, more details in internal ticket.

Note: for all these scenarios I set `V4_CFG_CAS_WORKER_COUNT: 3` in my ansible vars to ensure that the autoscaler functioned and provisioned the additional CAS nodes. I also ensured upon uninstall the unused nodes were automatically removed.

| Scenario | Task | Provider | initial viya4-iac-aws version  | kubernetes_version | Order  | Cadence        | Orchestration       | Deployment Method | V4_CFG_CAS_WORKER_COUNT | CLUSTER_AUTOSCALER_CHART_VERSION | kubectl Version | Notes                                                                                              |
|----------|------|----------|--------------------------------|--------------------|--------|----------------|---------------------|-------------------|-------------------------|----------------------------------|-----------------|----------------------------------------------------------------------------------------------------|
| 1        | OOTB | AWS      | IAC-903                        | 1.22               | ***** | lts:2022.09    | Deployment Operator | Docker            | 3                       | 9.9.2 (default)                  | 1.24.10         |                                                                                                    |
| 2        | OOTB | AWS      | IAC-903                        | 1.24               | ***** | stable:2023.02 | Deployment Operator | Docker            | 3                       | 9.9.2 (default)                  | 1.24.10         |                                                                                                    |
| 3        | OOTB | AWS      | IAC-903                        | 1.25               | ***** | fast:2020      | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         |                                                                                                    |
| 4        | OOTB | AWS      | 5.5.0                          | 1.25               | ***** | fast:2020      | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         | expected initial autoscaler install failure, verified that troubleshooting option 1 resolved issue |
| 4        | OOTB | AWS      | 5.5.0                          | 1.25               | ***** | fast:2020      | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         | expected initial autoscaler install failure, verified that troubleshooting option 2 resolved issue |

Two additional tests after review comments and changes

| Scenario | Task | Provider | initial viya4-iac-aws version  | kubernetes_version | Order  | Cadence   | Orchestration       | Deployment Method | V4_CFG_CAS_WORKER_COUNT | CLUSTER_AUTOSCALER_CHART_VERSION | kubectl Version | Notes                                                                                              |
|----------|------|----------|--------------------------------|--------------------|--------|-----------|---------------------|-------------------|-------------------------|----------------------------------|-----------------|----------------------------------------------------------------------------------------------------|
| 6        | OOTB | AWS      | IAC-903                        | 1.24               | * | fast:2020 | Deployment Operator | Docker            | 3                       | 9.9.2 (default)                  | 1.24.10         |                                                                                                    |
| 7        | OOTB | AWS      | IAC-903                        | 1.25               | * | fast:2020 | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         |       
