### PR TITLE
fix: (IAC-974) CAS instance fails to join kubernetes cluster using sample-input-ha.tfvars

### DIFF
--- a/files/custom-data/additional_userdata.sh
+++ b/files/custom-data/additional_userdata.sh
@@ -1,10 +1,10 @@
-# Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# Copyright 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 ##
-# 
+#
 # For AWS this is a script 'snippet' that is injected into another script
-# which performs tasks that are AWS specific. 
+# which performs tasks that are AWS specific.
 #
 # Link: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/templates/userdata.sh.tpl
 #


### PR DESCRIPTION
### Changes
Remove cloud-init incompatible copyright character from first line of custom-data cloud-init script.

shellcheck linter removed end of line spaces on lines 5 & 7.

The copyright character u'\xa9' is not a valid character for cloud-init scripts.

### Testing
Prior to update

|Scenario|Provider|K8S version|Order|terraform-input.tfvars|Process|Notes|
|-|-|-|-|-|-|-|
|1|AWS|1.24|n/a|sample-input-ha.tfvars|terraform apply -auto-approve -var-file sample-input-ha.tfvars -var location=us-west-2 -var prefix=davhou-507ha|Terraform apply fails with the failure to join kubernetes cluster error msg below |

```
Error: error waiting for EKS Node Group (davhou-507ha-eks:cas-20230330190117797700000029) to create: unexpected state 'CREATE_FAILED', wanted target 'ACTIVE'. last error: 1 error occurred: i-025a206ff6b734692: NodeCreationFailure: Instances failed to join the kubernetes cluster with module.eks.module.eks_managed_node_group["cas"].aws_eks_node_group.this[0], on .terraform/modules/eks/modules/eks-managed-node-group/main.tf line 269, in resource "aws_eks_node_group" "this":
```

After removing non-ascii copyright char from files/custom-data/additional_userdata.sh cloud-init script
|Scenario|Provider|K8S version|Order|terraform-input.tfvars|Process|Notes|
|-|-|-|-|-|-|-|
|2|AWS|1.24|n/a|sample-input-ha.tfvars|terraform apply -auto-approve -var-file sample-input-ha.tfvars -var location=us-west-2 -var prefix=davhou-507ha3|Terraform apply results in successful cluster creation where all created VMs including CAS VM join the cluster.|
