### PR TITLE
feat: (IAC-980) add K8s 1.26 support, set kubectl default to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.7.22
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.24.10
+ARG KUBECTL_VERSION=1.25.8
 
 WORKDIR /viya4-iac-aws
 
@@ -11,6 +11,7 @@ COPY --from=terraform /bin/terraform /bin/terraform
 COPY . .
 
 RUN yum -y install git openssh jq which \
+  && yum clean all && rm -rf /var/cache/yum
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=terraform /bin/terraform /bin/terraform
 COPY . .
 
 RUN yum -y install git openssh jq which \
-  && yum clean all && rm -rf /var/cache/yum
+  && yum clean all && rm -rf /var/cache/yum \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.24.10
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.25
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.7.22
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.25
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.25.8
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.7.22
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -197,7 +197,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | true | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.24" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.25" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 1
 default_nodepool_vm_type     = "m5.large"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.24"
+kubernetes_version           = "1.25"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/variables.tf
+++ b/variables.tf
@@ -103,7 +103,7 @@ variable "efs_performance_mode" {
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version."
   type        = string
-  default     = "1.24"
+  default     = "1.25"
 }
 
 variable "tags" {


### PR DESCRIPTION
# Changes:
SAS Viya Platform will support K8s 1.24-1.26 in cadence v2023.05. This change updates the default kubernetes version to `1.25` and kubectl to `1.25.8`.

# Tests:
Verify SAS Viya Platform deployment is successful for the following scenarios, see details in internal ticket:
|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method| Result |
|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|AWS|Stable 2023.04|1.24.11|docker, DO: false| Successful |
|2|OOTB|AWS|Stable 2023.04|1.25.7|ansible (staging), DO: true| Successful |
|3|OOTB|AWS|fast:2020|1.26.2|docker (test-1002), DO: false| Successful|

