### PR TITLE
fix: (IAC-1068) IAC jumpvm cloud-init, only set folder permissions and ownership initially

### DIFF
--- a/files/cloud-init/jump/cloud-config
+++ b/files/cloud-init/jump/cloud-config
@@ -31,10 +31,14 @@ runcmd:
       # mount the nfs
       #
   -   while [ `df -h | grep "${rwx_filestore_endpoint}:${rwx_filestore_path}" | wc -l` -eq 0 ]; do sleep 5 && mount -a ; done
-      #
-      # Change permissions and owener
-      #
-  -   mkdir -p ${jump_rwx_filestore_path}/pvs
-  -   chmod 777 ${jump_rwx_filestore_path} -R
-  -   chown -R nobody:nogroup ${jump_rwx_filestore_path}
+      # Create pvs folder and adjust perms and owner only if the folder doesn't exist
+  -   if ! [ -d "${jump_rwx_filestore_path}/pvs" ]
+  -   then
+        #
+        # Change permissions and owner
+        #
+  -     mkdir -p ${jump_rwx_filestore_path}/pvs
+  -     chmod 777 ${jump_rwx_filestore_path} -R
+  -     chown -R nobody:nogroup ${jump_rwx_filestore_path}
+  -   fi
   - fi


### PR DESCRIPTION
# Changes
When viya4-iac-aws creates a new jump server vm, it sets file ownership and permissions for the mounted NFS location which allows Viya services to initialize successfully. Importantly, the file system settings should only be applied once and not repeatedly in the event that the jump vm is destroyed and recreated in the same cluster. This change checks if the `${jump_rwx_filestore_path}/pvs` folder already exists and skips creating the folder and recursively setting ownerships and permissions if it does. If the jump vm is being created for the first time when the pvs folder is absent, creating the folder and setting permissions and ownership will occur an initial time and not thereafter.

# Tests
Steps:
 - Have an existing AWS cluster that was created using IaC
 - Verify infrastructure created successfully
 - Deploy Viya4 using DaC
 - Verify Viya deployment is stabilized
 - Stop Viya. Follow SAS doc [https://go.documentation.sas.com/doc/en/itopscdc/v_040/itopssrv/n0pwhguy22yhe0n1d7pgi63mf6pb.htm#p05jsfcz54bsejn1x1r34f0zrag6] "Stop a SAS Viya Platform Deployment"
 - Verify all pods are terminated
 - Run terraform apply, verifying that the existing jump vm is destroyed and a new one is created during the apply.
 - Start Viya following the SAS doc [https://go.documentation.sas.com/doc/en/itopscdc/v_040/itopssrv/n0pwhguy22yhe0n1d7pgi63mf6pb.htm#p05jsfcz54bsejn1x1r34f0zrag6]
 - Check deployment/pods status verifying that Viya services and applications including all sas-rabbitmq-server and sas-consul-server instances initialize successfully and begin Running stable again.