### PR TITLE
fix: (IAC-1036) AWS - Security scan remediation for High CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=terraform /bin/terraform /bin/terraform
 COPY . .
 
 RUN yum -y install git openssh jq which \
+  && yum -y update openssl-libs glib2 \
   && yum clean all && rm -rf /var/cache/yum \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=terraform /bin/terraform /bin/terraform
 COPY . .
 
 RUN yum -y install git openssh jq which \
-  && yum -y update openssl-libs glib2 \
+  && yum -y update openssl-libs glib2 vim-minimal vim-data curl \
   && yum clean all && rm -rf /var/cache/yum \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \

--- a/versions.tf
+++ b/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.4.0"
+      version = "4.0.4"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"


### PR DESCRIPTION
# Changes
- Update 5 rpms with identified high CVEs
- Update hashicorp/tls provider to 4.0.4 to remediate high CVEs present in the current version (no references to any of the resources with breaking changes are in use, otherwise just bug fixes and enhancements compared to the current provider version)

# Tests
See internal ticket for description of high CVEs still present with remediation plans.
- Create k8s 1.26 AWS cluster using sample-input.tfvars.
- Deploy Viya 2023.05 stable to the cluster and verified a stable deployment, successful administrator login to Viya application.

|Scenario| Method| Provider| K8s version| Cadence| Notes |
|-|-|-|-|-|-|
|1| docker| AWS | v1.26.5-eks | 2023.05:stable | external postgres|
