### PR TITLE
feat: (IAC-722) update terraform-aws-eks module version

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -57,7 +57,8 @@ You can use either static credentials or the name of an AWS profile. If both are
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | aws_profile | Name of AWS Profile in the credentials file | string | "" | |
-| aws_shared_credentials_file | Path to credentials file | string | [`~/.aws/credentials` on Linux and macOS](https://docs.aws.amazon.com/credref/latest/refdocs/file-location.html) | Can be ignored when using the default value. |
+| aws_shared_credentials_file | Path to shared credentials file | string | [`~/.aws/credentials` on Linux and macOS](https://docs.aws.amazon.com/credref/latest/refdocs/file-location.html) | **`aws_shared_credentials_file` is deprecated and will be removed in a future release**: use `aws_shared_credentials_files` instead. Can be ignored when using the default value. `aws_shared_credentials_file` and `aws_shared_credentials_files` are mutually exclusive, configure one or the other but not both. |
+| aws_shared_credentials_files | List of paths to shared credentials files. | list of strings | [[`~/.aws/credentials`] on Linux and macOS](https://docs.aws.amazon.com/credref/latest/refdocs/file-location.html) | Can be ignored when using the default value. `aws_shared_credentials_file` and `aws_shared_credentials_files` are mutually exclusive, configure one or the other but not both.|
 
 ## Admin Access
 

--- a/locals.tf
+++ b/locals.tf
@@ -10,6 +10,7 @@ locals {
   cluster_name              = "${var.prefix}-eks"
   default_tags              = { project_name = "viya" }
   tags                      = var.tags == null ? local.default_tags : length(var.tags) == 0 ? local.default_tags : var.tags
+  aws_shared_credentials    = var.aws_shared_credentials_file == "" ? var.aws_shared_credentials_files : [var.aws_shared_credentials_file]
 
   # CIDRs
   default_public_access_cidrs           = var.default_public_access_cidrs == null ? [] : var.default_public_access_cidrs

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,11 @@ locals {
   cluster_name              = "${var.prefix}-eks"
   default_tags              = { project_name = "viya" }
   tags                      = var.tags == null ? local.default_tags : length(var.tags) == 0 ? local.default_tags : var.tags
-  aws_shared_credentials    = var.aws_shared_credentials_file == "" ? var.aws_shared_credentials_files : [var.aws_shared_credentials_file]
+
+  # aws_shared_credentials_file - is DEPRECATED and will be removed in a future release
+  use_aws_shared_credentials_file = var.aws_shared_credentials_file != null ? length(var.aws_shared_credentials_file) > 0 ? true : false : false
+  # Assign correct credential file value - If the old value is false, then new value must be used.
+  aws_shared_credentials          = local.use_aws_shared_credentials_file ? [var.aws_shared_credentials_file] : var.aws_shared_credentials_files
 
   # CIDRs
   default_public_access_cidrs           = var.default_public_access_cidrs == null ? [] : var.default_public_access_cidrs

--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,13 @@
 #
 
 provider "aws" {
-  region                  = var.location
-  profile                 = var.aws_profile
-  shared_credentials_file = var.aws_shared_credentials_file
-  access_key              = var.aws_access_key_id
-  secret_key              = var.aws_secret_access_key
-  token                   = var.aws_session_token
+  region                   = var.location
+  profile                  = var.aws_profile
+  shared_credentials_files = local.aws_shared_credentials
+  access_key               = var.aws_access_key_id
+  secret_key               = var.aws_secret_access_key
+  token                    = var.aws_session_token
+
 }
 
 data "aws_eks_cluster" "cluster" {
@@ -202,10 +203,10 @@ module "kubeconfig" {
   depends_on = [module.eks.cluster_id] # The name/id of the EKS cluster. Will block on cluster creation until the cluster is really ready.
 }
 
-# Database Setup - https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/3.3.0
+# Database Setup - https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/5.9.0
 module "postgresql" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "3.3.0"
+  version = "5.9.0"
 
   for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
 

--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/aws_ebs_csi/main.tf
+++ b/modules/aws_ebs_csi/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/aws_vm/main.tf
+++ b/modules/aws_vm/main.tf
@@ -3,7 +3,7 @@
 
 # Reference: https://github.com/terraform-providers/terraform-provider-aws
 
-# Hack for assigning disk in a vm based on an index value. 
+# Hack for assigning disk in a vm based on an index value.
 locals {
   device_name = [
     # "/dev/sdb", - NOTE: These are skipped, Ubuntu Server 20.04 LTS
@@ -89,7 +89,7 @@ resource "aws_instance" "vm" {
 
 resource "aws_eip" "eip" {
   count    = var.create_public_ip ? 1 : 0
-  vpc      = true
+  domain   = "vpc"
   instance = aws_instance.vm.id
   tags     = merge(var.tags, tomap({ Name : "${var.name}-eip" }))
 }

--- a/modules/aws_vpc/main.tf
+++ b/modules/aws_vpc/main.tf
@@ -250,7 +250,7 @@ resource "aws_db_subnet_group" "database" {
 resource "aws_eip" "nat" {
   count = var.existing_nat_id == null ? 1 : 0
 
-  vpc = true
+  domain = "vpc"
 
   tags = merge(
     {
@@ -266,7 +266,7 @@ resource "aws_eip" "nat" {
 
 data "aws_nat_gateway" "nat_gateway" {
   count = var.existing_nat_id != null ? 1 : 0
-  id    = var.existing_nat_id # alt. support vpc_id or subnet_id where NAT 
+  id    = var.existing_nat_id # alt. support vpc_id or subnet_id where NAT
 }
 
 resource "aws_nat_gateway" "nat_gateway" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -143,3 +143,11 @@ output "ebs_csi_account" {
 output "k8s_version" {
   value = data.aws_eks_cluster.cluster.version
 }
+
+output "aws_shared_credentials" {
+  value = local.aws_shared_credentials
+  precondition {
+    condition = length(var.aws_shared_credentials_file) == 0 || var.aws_shared_credentials_files == null
+    error_message = "Set either aws_shared_credentials_files or aws_shared_credentials_file, but not both. aws_shared_credentials_file is deprecated and will be removed in a future release, use aws_shared_credentials_files instead."
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -144,6 +144,14 @@ output "k8s_version" {
   value = data.aws_eks_cluster.cluster.version
 }
 
+output "aws_shared_credentials_file" {
+  value = var.aws_shared_credentials_file
+  precondition {
+    condition = var.aws_shared_credentials_file != null
+    error_message = "aws_shared_credentials_file must not be null. aws_shared_credentials_file has been deprecated and will be removed in a future release, use aws_shared_credentials_files instead."
+  }
+}
+
 output "aws_shared_credentials" {
   value = local.aws_shared_credentials
   precondition {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "aws_shared_credentials_file" {
   default     = ""
 }
 
+variable "aws_shared_credentials_files" {
+  description = "List of paths to shared credentials files, if using non-default location."
+  type        = list(string)
+  default     = null
+}
+
 variable "aws_session_token" {
   description = "Session token for temporary credentials."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.76.1"
+      version = "5.4.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
# Changes
- add new `aws_shared_credentials_files` input variable
- add CONFIG-VARS.md text indicating `aws_shared_credentials_file` input variable has been deprecated and will be removed in a future release
- add precondition check and error message to warn against configuring both `aws_shared_credentials_file` and `aws_shared_credentials_files` input variables at the same time and encourage the use of the newer variable instead of the deprecated variable.
- update required child module provider versions to 5.0+
- required `aws_eip` resource attribute changes

# Tests
| Scenario | `create_static_kubeconfig` | `aws_shared_credentials_file` | `aws_shared_credentials_files` | Plan results |
|----------|--------|-------|--------|-----------------------------------------------|
| 1 | false | not specified | not specified | successful  |
| 2 | false | null | not specified | fatal Error: `aws_shared_credentials_file` must not be null. `aws_shared_credentials_file` has been deprecated and will be removed in a future release, use `aws_shared_credentials_files` instead.  |
| 3 | false | not specified | null |  successful  |
| 4 | false | null | null | fatal Error: `aws_shared_credentials_file` must not be null. `aws_shared_credentials_file` has been deprecated and will be removed in a future release, use `aws_shared_credentials_files` instead. |
| 5 | false | "" | null | successful |
| 6 | false | "" | [""] | successful |
| 7 | false | "" | ["~/.aws/credentials"] | successful |
| 8 | false | "~/.aws/credentials" | ["~/.aws/credentials"] | fatal Error: Set either `aws_shared_credentials_files` or `aws_shared_credentials_file`, but not both. `aws_shared_credentials_file` is deprecated and will be removed in a future release, use `aws_shared_credentials_files` instead. |