### PR TITLE
feat!: (IAC-722) restore previous aws-rds module behavior, set create_random_password=false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -258,6 +258,7 @@ module "postgresql" {
   create_db_subnet_group    = true
   create_db_parameter_group = true
   create_db_option_group    = true
+  create_random_password    = false
 
 }
 # Resource Groups - https://www.terraform.io/docs/providers/aws/r/resourcegroups_group.html


### PR DESCRIPTION
Testing the updates in https://github.com/sassoftware/viya4-iac-aws/pull/218 revealed that manually setting an external postgres administrator_password resulted in a failing Viya deployment due to an unexpected postgres adminstrator_password value in terraform.tfstate

The [4.0 upgrade guide](https://github.com/terraform-aws-modules/terraform-aws-rds/blob/master/UPGRADE-4.0.md) for the terraform-aws-rds module points out that the create_random_password variable is now set to `true` while it was previously set to `false`.

# Changes
- Update iac-aws to restore the previous setting of create_random_password to `false`. Doing so allows for manually setting an adminstrator_password as before, as well as restoring the documented default administrator_password in the event that no administrator_password is configured.

# Testing

|Scenario|task|.tfvars administrator_password value|Notes on terraform.tfstate content after apply action|
|--|--|--|--|
|1| No administrator_password set for default postgres instance| undefined | terraform apply updated terraform.tfstate with the expected default password that iac-aws has documented in CONFIG-VARS.md |
|2| Set administrator_password for default postgres instance | "mypassword" | terraform apply updated terraform.tfstate with the expected "mypassword" value instead of the random password value noticed during testing that occurred before this change.
