### PR TITLE
fix: (IAC-1165) Error: attaching policy msg occurs with a previously working tfvars file

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -294,6 +294,8 @@ When `storage_type=ha` and `storage_type_backend=ontap`, an [AWS FSx for NetApp 
 | aws_fsx_ontap_file_system_throughput_capacity | The throughput capacity of the ONTAP file system in MBps. | number | 256 | Valid values are 128, 256, 512, 1024, 2048 and 4096. |
 | aws_fsx_ontap_fsxadmin_password | The ONTAP administrative password for the fsxadmin user. | string | "v3RyS3cretPa$sw0rd" | |
 
+**Note:** The base [IAM Policy](../files/policies/devops-iac-eks-policy.json) document has been updated for the 7.2.0 release to suport FSx for NetApp ONTAP. You will need to add the iam:AttachUserPolicy and iam:DetachUserPolicy permissions to your user's existing base policy document to use FSx for NetApp ONTAP features added in the 7.2.0 release.
+
 ### AWS Elastic Block Store (EBS)
 
 [AWS Elastic Block Store](https://aws.amazon.com/ebs/) is a block-level storage service provided by AWS for use with EC2 instances. EBS provides persistent storage for EC2 instances, allowing data to persist even after an EC2 instance is stopped or terminated. EBS volumes can be used as the root device for an EC2 instance, or as additional storage volumes. They can be attached and detached from instances as needed and can also be encrypted for increased security.

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -294,7 +294,7 @@ When `storage_type=ha` and `storage_type_backend=ontap`, an [AWS FSx for NetApp 
 | aws_fsx_ontap_file_system_throughput_capacity | The throughput capacity of the ONTAP file system in MBps. | number | 256 | Valid values are 128, 256, 512, 1024, 2048 and 4096. |
 | aws_fsx_ontap_fsxadmin_password | The ONTAP administrative password for the fsxadmin user. | string | "v3RyS3cretPa$sw0rd" | |
 
-**Note:** The base [IAM Policy](../files/policies/devops-iac-eks-policy.json) document has been updated for the 7.2.0 release to suport FSx for NetApp ONTAP. You will need to add the iam:AttachUserPolicy and iam:DetachUserPolicy permissions to your user's existing base policy document to use FSx for NetApp ONTAP features added in the 7.2.0 release.
+**Note:** The base [IAM Policy](../files/policies/devops-iac-eks-policy.json) document has been updated for the 7.2.0 release to support FSx for NetApp ONTAP. You will need to add the iam:AttachUserPolicy and iam:DetachUserPolicy permissions to your user's existing base policy document to use FSx for NetApp ONTAP features added in the 7.2.0 release.
 
 ### AWS Elastic Block Store (EBS)
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -291,7 +291,7 @@ When `storage_type=ha` and `storage_type_backend=ontap`, an [AWS FSx for NetApp 
 | :--- | :--- | :--- | :--- | :--- |
 | aws_fsx_ontap_deployment_type | The FSx file system availability zone deployment type. | string | SINGLE_AZ_1 | Supported values are `MULTI_AZ_1` and `SINGLE_AZ_1`. |
 | aws_fsx_ontap_file_system_storage_capacity | The storage capacity of the ONTAP file system in GiB. | number | 1024 | Valid values range from  1024 to 196608. |
-| aws_fsx_ontap_file_system_throughput_capacity | The throughput capacity of the ONTAP file system in MBps. | number | 512 | Valid values are 128, 256, 512, 1024, 2048 and 4096. |
+| aws_fsx_ontap_file_system_throughput_capacity | The throughput capacity of the ONTAP file system in MBps. | number | 256 | Valid values are 128, 256, 512, 1024, 2048 and 4096. |
 | aws_fsx_ontap_fsxadmin_password | The ONTAP administrative password for the fsxadmin user. | string | "v3RyS3cretPa$sw0rd" | |
 
 ### AWS Elastic Block Store (EBS)

--- a/main.tf
+++ b/main.tf
@@ -190,9 +190,9 @@ module "ebs" {
 
 module "ontap" {
   source = "./modules/aws_fsx_ontap"
+  count  = var.storage_type_backend == "ontap" ? 1 : 0
 
   prefix        = var.prefix
-  cluster_name  = local.cluster_name
   tags          = local.tags
   iam_user_name = local.aws_caller_identity_user_name
 }

--- a/modules/aws_fsx_ontap/main.tf
+++ b/modules/aws_fsx_ontap/main.tf
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "fsx_ontap" {
 
 resource "aws_iam_policy" "fsx_ontap" {
   name_prefix = "${var.prefix}-fsx-ontap"
-  description = "FSx policy document for user ${data.aws_iam_user.terraform.user_name}"
+  description = "FSx policy for user ${data.aws_iam_user.terraform.user_name}"
   policy      = data.aws_iam_policy_document.fsx_ontap.json
   tags        = var.tags
 }

--- a/modules/aws_fsx_ontap/main.tf
+++ b/modules/aws_fsx_ontap/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Permissions based off the IAM Policies required to manage fsx_ontap resources in this project
-data "aws_iam_policy_document" "worker_fsx_ontap" {
+data "aws_iam_policy_document" "fsx_ontap" {
   statement {
     sid       = "fsxFileSystemOwn"
     effect    = "Allow"
@@ -66,10 +66,10 @@ data "aws_iam_policy_document" "worker_fsx_ontap" {
   }
 }
 
-resource "aws_iam_policy" "worker_fsx_ontap" {
+resource "aws_iam_policy" "fsx_ontap" {
   name_prefix = "${var.prefix}-fsx-ontap"
-  description = "EKS worker node fsx_ontap policy for cluster ${var.cluster_name}"
-  policy      = data.aws_iam_policy_document.worker_fsx_ontap.json
+  description = "FSx policy document for user ${data.aws_iam_user.terraform.user_name}"
+  policy      = data.aws_iam_policy_document.fsx_ontap.json
   tags        = var.tags
 }
 
@@ -79,5 +79,5 @@ data "aws_iam_user" "terraform" {
 
 resource "aws_iam_user_policy_attachment" "attachment" {
   user       = data.aws_iam_user.terraform.user_name
-  policy_arn = aws_iam_policy.worker_fsx_ontap.arn
+  policy_arn = aws_iam_policy.fsx_ontap.arn
 }

--- a/modules/aws_fsx_ontap/variables.tf
+++ b/modules/aws_fsx_ontap/variables.tf
@@ -7,12 +7,6 @@ variable "prefix" {
   default     = ""
 }
 
-variable "cluster_name" {
-  description = "Name of EKS cluster"
-  type        = string
-  default     = ""
-}
-
 variable "tags" {
   description = "Tags used for fsx_ontap"
   type        = map(any)


### PR DESCRIPTION
### Changes

- only create and attach required FSx policy document when FSx for NetApp ONTAP file system is configured with storage_type=ha, storage_type_backend=ontap
- update the documented default value for aws_fsx_ontap_file_system_throughput_capacity input variable
- remove unused variable reference

### Tests
| Scenario | Base Policy includes iam:AttachUserPolicy & iam:DetachUserPolicy | storage_type | storage_type_backend | Notes |
|-|-|-|-|-|
|1| true | ha | efs | successful cluster creation with EFS file system, no FSx policy doc created |
|2| true | ha | ontap | successful cluster creation, FSx policy doc created and attached to user |
|3| false | ha | undefined | successful cluster creation with EFS file system, no FSx policy doc created or attached, no terraform attach policy error |