### PR TITLE
fix: (IAC-923) Update Node Pool IAM Role Names to Include Prefix

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -87,6 +87,9 @@ locals {
       launch_template_use_name_prefix = true
       launch_template_tags            = { Name = "${local.cluster_name}-default" }
       tags                            = var.autoscaling_enabled ? merge(local.tags, { key = "k8s.io/cluster-autoscaler/${local.cluster_name}", value = "owned", propagate_at_launch = true }, { key = "k8s.io/cluster-autoscaler/enabled", value = "true", propagate_at_launch = true }) : local.tags
+      # Node Pool IAM Configuration
+      iam_role_use_name_prefix = false
+      iam_role_name = "${var.prefix}-default-eks-node-group"
     }
   }
 
@@ -133,6 +136,9 @@ locals {
       launch_template_use_name_prefix = true
       launch_template_tags            = { Name = "${local.cluster_name}-${key}" }
       tags                            = var.autoscaling_enabled ? merge(local.tags, { key = "k8s.io/cluster-autoscaler/${local.cluster_name}", value = "owned", propagate_at_launch = true }, { key = "k8s.io/cluster-autoscaler/enabled", value = "true", propagate_at_launch = true }) : local.tags
+      # Node Pool IAM Configuration
+      iam_role_use_name_prefix = false
+      iam_role_name = "${var.prefix}-${key}-eks-node-group"
     }
   }
 


### PR DESCRIPTION
### Changes
Update the naming of the node pool IAM roles. Before this change the roles were an autogenerated name based off just the node pool name which made them hard to track, especially if you are working with multiple clusters. This change makes it so that the name will now include the `prefix` value in additional to the node names when the roles are created.

e.g.  the roles are now `cas-eks-node-group-[timestamp-unique]` -> `my-cool-prefix-cas-eks-node-group`

This is not a breaking change either, if you rerun apply using this PR using an earlier release the node pool IAM roles will just be replaced with ones with the updated names and associated with the existing node pools.

### Tests

| Scenario | Provider | K8s Version         | Order  | Cadence   | Notes                                                                                      |
|----------|----------|---------------------|--------|-----------|--------------------------------------------------------------------------------------------|
| 1        | AWS      | v1.26.7-eks-2d98532 | * | fast:2020 | OOTB                                                                                       |
| 2        | AWS      | v1.26.7-eks-2d98532 | * | fast:2020 | Initially created infra with v7.2.1 and reran apply with PR codebase to replace role names |
