### PR TITLE
feat!: EKS Node Pool Subnets to use Single AZ by Default

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -209,6 +209,7 @@ Custom policy:
 | autoscaling_enabled | Enable cluster autoscaling | bool | true | |
 | ssh_public_key | File name of public ssh key for jump and nfs VM | string | "~/.ssh/id_rsa.pub" | Required with `create_jump_vm=true` or `storage_type=standard` |
 | cluster_api_mode | Public or private IP for the cluster api| string|"public"|Valid Values: "public", "private" |
+| enable_multi_zone | Set to true to deploy EKS Node Pools in multiple availability zones | boolean | false | **WARNING: changing this from true to false after infrastructure creation is destructive** |
 
 ## Node Pools
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -41,7 +41,7 @@ Terraform input variables can be set in the following ways:
 
 ### AWS Authentication
 
-The Terraform process manages AWS resources on your behalf. In order to do so, it needs the credentials for an AWS identity with the required permissons.
+The Terraform process manages AWS resources on your behalf. In order to do so, it needs the credentials for an AWS identity with the required permissions.
 
 You can use either static credentials or the name of an AWS profile. If both are specified, the static credentials take precedence. For recommendations on how to set these variables in your environment, see [Authenticating Terraform to Access AWS](./user/TerraformAWSAuthentication.md).
 
@@ -63,7 +63,7 @@ You can use either static credentials or the name of an AWS profile. If both are
 
 ## Admin Access
 
-By default, the pubic endpoints of the AWS resources that are being created are only accessible through authenticated AWS clients (for example, the AWS Portal, the AWS CLI, etc.).
+By default, the public endpoints of the AWS resources that are being created are only accessible through authenticated AWS clients (for example, the AWS Portal, the AWS CLI, etc.).
 To enable access for other administrative client applications (for example `kubectl`, `psql`, etc.), you can set Security Group rules to control access from your source IP addresses.
 
 To set these permissions as part of this Terraform script, specify ranges of IP addresses in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing). Contact your Network Administrator to find the public CIDR range of your network.
@@ -112,11 +112,11 @@ The variables in the table below can be used to define the existing resources. R
  | nat_id | ID of existing AWS NAT gateway | string | null | Only required if deploying into existing VPC and subnets. |
  | security_group_id | ID of existing Security Group that controls external access to Jump/NFS VMs and Postgres | string | null | Only required if using existing Security Group. See [Security Group](./user/BYOnetwork.md#external-access-security-group) for requirements. |
 | cluster_security_group_id | ID of existing Security Group that controls Pod access to the control plane | string | null | Only required if using existing Cluster Security Group. See [Cluster Security Group](./user/BYOnetwork.md#cluster-security-group) for requirements.|
-| workers_security_group_id | ID of existing Security Group that allows access between node VMs, Jump VM, and data sourcess (nfs, efs, postges) | string | null | Only required if using existing Security Group for Node Group VMs. See [Workers Security Group](./user/BYOnetwork.md#workers-security-group) for requirements. |
+| workers_security_group_id | ID of existing Security Group that allows access between node VMs, Jump VM, and data sources (nfs, efs, postges) | string | null | Only required if using existing Security Group for Node Group VMs. See [Workers Security Group](./user/BYOnetwork.md#workers-security-group) for requirements. |
 
 Example `subnet_ids` variable:
 
-```yaml
+```terraform
 subnet_ids = {
   "public" : ["existing-public-subnet-id1", "existing-public-subnet-id2"],
   "private" : ["existing-private-subnet-id1", "existing-private-subnet-id2"],
@@ -336,7 +336,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | backup_retention_days | Backup retention days for the PostgreSQL server | number | 7 | Supported values are between 7 and 35 days. |
 | storage_encrypted | Encrypt PostgreSQL data at rest | bool | false| |
 | administrator_login | The Administrator Login for the PostgreSQL Server | string | "pgadmin" | The admin login name can not be 'admin', must start with a letter, and must be between 1-16 characters in length, and can only contain underscores, letters, and numbers. Changing this forces a new resource to be created |
-| administrator_password | The Password associated with the administrator_login for the PostgreSQL Server | string | "my$up3rS3cretPassw0rd" | The admin passsword must have more than 8 characters, and be composed of any printable characters except the following / ' \" @ characters. |
+| administrator_password | The Password associated with the administrator_login for the PostgreSQL Server | string | "my$up3rS3cretPassw0rd" | The admin password must have more than 8 characters, and be composed of any printable characters except the following / ' \" @ characters. |
 | multi_az | Specifies if PostgreSQL instance is multi-AZ | bool | false | |
 | deletion_protection | Protect from accidental resource deletion | bool | false | |
 | ssl_enforcement_enabled | Enforce SSL on connections to PostgreSQL server instance | bool | true | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -209,7 +209,7 @@ Custom policy:
 | autoscaling_enabled | Enable cluster autoscaling | bool | true | |
 | ssh_public_key | File name of public ssh key for jump and nfs VM | string | "~/.ssh/id_rsa.pub" | Required with `create_jump_vm=true` or `storage_type=standard` |
 | cluster_api_mode | Public or private IP for the cluster api| string|"public"|Valid Values: "public", "private" |
-| enable_multi_zone | Set to true to deploy EKS Node Pools in multiple availability zones | boolean | false | **WARNING**: changing this from true to false after infrastructure creation is destructive. If you have an existing Viya deployment in your cluster, following the [SAS Viya Platform Operations backup and restore documentation](https://go.documentation.sas.com/doc/en/itopscdc/v_044/itopsmigwlcm/home.htm) is recommended before changing this. |
+| enable_multi_zone | Set to true to deploy EKS Node Pools in multiple availability zones | boolean | false | **WARNING**: changing this from true to false after infrastructure creation is destructive. If you have an existing Viya deployment in your cluster, following the [SAS Viya Platform Operations backup and restore documentation](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopsmigwlcm&docsetTarget=home.htm) is recommended before changing this. |
 
 ## Node Pools
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -209,7 +209,7 @@ Custom policy:
 | autoscaling_enabled | Enable cluster autoscaling | bool | true | |
 | ssh_public_key | File name of public ssh key for jump and nfs VM | string | "~/.ssh/id_rsa.pub" | Required with `create_jump_vm=true` or `storage_type=standard` |
 | cluster_api_mode | Public or private IP for the cluster api| string|"public"|Valid Values: "public", "private" |
-| enable_multi_zone | Set to true to deploy EKS Node Pools in multiple availability zones | boolean | false | **WARNING: changing this from true to false after infrastructure creation is destructive** |
+| enable_multi_zone | Set to true to deploy EKS Node Pools in multiple availability zones | boolean | false | **WARNING**: changing this from true to false after infrastructure creation is destructive. If you have an existing Viya deployment in your cluster, following the [SAS Viya Platform Operations backup and restore documentation](https://go.documentation.sas.com/doc/en/itopscdc/v_044/itopsmigwlcm/home.htm) is recommended before changing this. |
 
 ## Node Pools
 

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -32,6 +32,9 @@ default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""
 
+# This forces all worker nodes to run in a single zone and is required when deploying a 'singlestore' node pool.
+enable_multi_zone = false
+
 ## General
 efs_performance_mode = "maxIO"
 storage_type         = "standard"

--- a/files/policies/devops-iac-eks-policy.json
+++ b/files/policies/devops-iac-eks-policy.json
@@ -145,6 +145,7 @@
                 "iam:TagPolicy",
                 "iam:TagInstanceProfile",
                 "iam:TagOpenIDConnectProvider",
+                "iam:UpdateOpenIDConnectProviderThumbprint",
                 "iam:UntagPolicy",
                 "iam:UpdateAssumeRolePolicy",
                 "iam:UpdateAccessKey",

--- a/files/policies/devops-iac-eks-policy.json
+++ b/files/policies/devops-iac-eks-policy.json
@@ -145,7 +145,6 @@
                 "iam:TagPolicy",
                 "iam:TagInstanceProfile",
                 "iam:TagOpenIDConnectProvider",
-                "iam:UpdateOpenIDConnectProviderThumbprint",
                 "iam:UntagPolicy",
                 "iam:UpdateAssumeRolePolicy",
                 "iam:UpdateAccessKey",

--- a/main.tf
+++ b/main.tf
@@ -97,8 +97,10 @@ module "eks" {
   cluster_endpoint_public_access       = var.cluster_api_mode == "public" ? true : false
   cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
 
-  control_plane_subnet_ids = module.vpc.private_subnets                                                           # AWS requires two or more subnets in different Availability Zones for your cluster's control plane.
-  subnet_ids               = var.enable_multi_zone ? module.vpc.private_subnets : [module.vpc.private_subnets[0]] # Specifies the list of subnets in which the worker nodes of the EKS cluster will be launched.
+  # AWS requires two or more subnets in different Availability Zones for your cluster's control plane.
+  control_plane_subnet_ids = module.vpc.private_subnets
+  # Specifies the list of subnets in which the worker nodes of the EKS cluster will be launched.
+  subnet_ids               = var.enable_multi_zone ? module.vpc.private_subnets : [module.vpc.private_subnets[0]]
   vpc_id                   = module.vpc.vpc_id
   tags                     = local.tags
   enable_irsa              = var.autoscaling_enabled

--- a/main.tf
+++ b/main.tf
@@ -97,10 +97,11 @@ module "eks" {
   cluster_endpoint_public_access       = var.cluster_api_mode == "public" ? true : false
   cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
 
-  subnet_ids  = module.vpc.private_subnets
-  vpc_id      = module.vpc.vpc_id
-  tags        = local.tags
-  enable_irsa = var.autoscaling_enabled
+  control_plane_subnet_ids = module.vpc.private_subnets                                                           # AWS requires two or more subnets in different Availability Zones for your cluster's control plane.
+  subnet_ids               = var.enable_multi_zone ? module.vpc.private_subnets : [module.vpc.private_subnets[0]] # Specifies the list of subnets in which the worker nodes of the EKS cluster will be launched.
+  vpc_id                   = module.vpc.vpc_id
+  tags                     = local.tags
+  enable_irsa              = var.autoscaling_enabled
   ################################################################################
   # Cluster Security Group
   ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -233,7 +233,7 @@ variable "default_nodepool_metadata_http_put_response_hop_limit" {
 }
 
 variable "enable_multi_zone" {
-  description = "Should be true to deploy EKS in multiple availability zones."
+  description = "Set to true to deploy EKS Node Pools in multiple availability zones."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -232,6 +232,12 @@ variable "default_nodepool_metadata_http_put_response_hop_limit" {
   default     = 1
 }
 
+variable "enable_multi_zone" {
+  description = "Should be true to deploy EKS in multiple availability zones."
+  type        = bool
+  default     = false
+}
+
 ## Dynamic node pool config
 variable "node_pools" {
   description = "Node Pool Definitions."


### PR DESCRIPTION
### Changes

In order to line up with the recommendations from the SAS Viya Platform Operations documentation we are updating the code base so that when EKS node groups are created they will be placed in a single-AZ rather than spanning over multiple-AZs. This feature is controlled by the new variable `enable_multi_zone` which by default will be set to false, resulting in the node groups being a single subnet in a single-az.

This is considered a breaking change single since users who initially created their infrastructure with viya4-iac-aws:7.2.1 or earlier, and want to use the new version to make adjustments to their infrastructure will now have their node groups moved to a single-az. If they have a stopped Viya deployment they were planning on starting after the infrastructure updates, they will most likely run in SAS Viya pod instability as they try to get it back online. Our recommendation for those users is to set `enable_multi_zone` to true when they run `apply` again to keep their node groups in a multi-az configuration so that the Viya pods are unaffected. Alternatively if the user wants to move over to a single-az configuration from their previous multi-az deployment following the SAS Viya Platform Operation [backup and restore documentation](https://go.documentation.sas.com/doc/en/itopscdc/v_044/itopsmigwlcm/home.htm) is recommended.


Relevant SAS Viya Platform documentation for AWS Cluster Requirements:
https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n098rczq46ffjfn1xbgfzahytnmx.htm#p0vx68bmb3fs88n12d73wwxpsnhu





### Tests

Put tests in comment for better formatting:
https://github.com/sassoftware/viya4-iac-aws/pull/234#issuecomment-1736154082
