### PR TITLE
feat: (IAC-1078) Linting Updates and Code Formatting

### DIFF
--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -54,9 +54,6 @@ jobs:
         tflint_version: latest
         github_token: ${{ secrets.LINTER_TEST_TOKEN }}
 
-    - name: Initializing viya4-iac-aws
-      run: terraform init
-
       # Necessary so we can recursively tflint our modules folder
       # with the plugin, not needed for regular project use.
     - name: Initializing modules

--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -2,7 +2,7 @@ name: Linter Analysis
 
 on:
   push:
-    branches: [ '**' ] # '*8' will cause the workflow to run on all commits to all branches, including those with path separators
+    branches: [ '**' ] # '**' will cause the workflow to run on all commits to all branches, including those with path separators
 
 jobs:
   # Hadolint: Job-1

--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -2,7 +2,7 @@ name: Linter Analysis
 
 on:
   push:
-    branches: ['*'] # '*' will cause the workflow to run on all commits to all branches.
+    branches: [ '**' ] # '*8' will cause the workflow to run on all commits to all branches, including those with path separators
 
 jobs:
   # Hadolint: Job-1
@@ -54,8 +54,18 @@ jobs:
         tflint_version: latest
         github_token: ${{ secrets.LINTER_TEST_TOKEN }}
 
+    - name: Initializing viya4-iac-aws
+      run: terraform init
+
+      # Necessary so we can recursively tflint our modules folder
+      # with the plugin, not needed for regular project use.
+    - name: Initializing modules
+      run: |
+       terraform -chdir=modules/aws_autoscaling init
+       terraform -chdir=modules/aws_ebs_csi init
+
     - name: Initializing TFLint
-      run: TFLINT_LOG=info tflint --init -c .tflint.hcl 
+      run: TFLINT_LOG=info tflint --init -c "$(pwd)/linting-configs/.tflint.hcl"
 
     - name: Run TFLint Action
-      run: TFLINT_LOG=info tflint -c .tflint.hcl 
+      run: TFLINT_LOG=info tflint -c "$(pwd)/linting-configs/.tflint.hcl" --recursive

--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -9,7 +9,7 @@
 
 config {
   # Enables module inspection.
-  module = true
+  module = false
 }
 
 plugin "aws" {

--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -9,12 +9,12 @@
 
 config {
   # Enables module inspection.
-  module = false
+  module = true
 }
 
 plugin "aws" {
   enabled = true
-  version = "0.23.0"
+  version = "0.27.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/modules/aws_vm/variables.tf
+++ b/modules/aws_vm/variables.tf
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 variable "name" {
+  description = "Name to assign the VM"
   type = string
 }
 
@@ -12,77 +13,102 @@ variable "tags" {
 }
 
 variable "vm_type" {
+  description = "EC2 instance type"
+  type        = string
   default = "m5.4xlarge"
 }
 
 variable "cloud_init" {
+  description = "Cloud init script to execute"
+  type        = string
   default = ""
 }
 
-variable "postgres_administrator_login" {
-  description = "The Administrator Login for the PostgreSQL Server. Changing this forces a new resource to be created."
-  default     = "pgadmin"
-}
-
 variable "vm_admin" {
-  description = "OS Admin User for VMs of AKS Cluster nodes"
+  description = "OS Admin User for VMs of EC2 instance"
+  type        = string
   default     = "azureuser"
 }
 
 variable "ssh_public_key" {
   description = "Path to ssh public key"
+  type        = string
   default     = ""
 }
 
 variable "security_group_ids" {
+  description = "List of security group ids to associate with the EC2 instance"
+  type        = list(string)
   default = []
 }
 
 variable "create_public_ip" {
+  description = "Toggle the creation of a public EIP to be associated with the EC2 instance"
+  type        = bool
   default = false
 }
 
 variable "data_disk_count" {
+  description = "Number of disks to attach to the EC2 instance"
+  type        = number
   default = 0
 }
 
 variable "data_disk_size" {
+  description = "Size of disk to attach to the EC2 instance in GiBs"
+  type        = number
   default = 128
 }
 
 variable "data_disk_type" {
+  description = "The type of EBS volume for the data disk"
+  type        = string
   default = "gp2"
 }
 
 variable "data_disk_availability_zone" {
+  description = "The AZ where the EBS volume will exist"
+  type        = string
   default = ""
 }
 
 variable "data_disk_iops" {
+  description = "The amount of IOPS to provision for the data disk"
+  type        = number
   default = 0
 }
 
 variable "os_disk_size" {
+  description = "The size of the OS disk"
+  type        = number
   default = 64
 }
 
 variable "os_disk_type" {
+  description = "The type of EBS volume for the OS disk"
+  type        = string
   default = "standard"
 }
 
 variable "os_disk_delete_on_termination" {
+  description = "Delete disk on termination"
+  type        = bool
   default = true
 }
 
 variable "os_disk_iops" {
+  description = "The amount of IOPS to provision for the OS disk"
+  type        = number
   default = 0
 }
 
 variable "subnet_id" {
+  description = "The VPC Subnet ID to launch in."
   type = string
 }
 
 variable "enable_ebs_encryption" {
   description = "Enable encryption on EBS volumes."
+  type        = bool
   default     = false
 }

--- a/modules/aws_vm/variables.tf
+++ b/modules/aws_vm/variables.tf
@@ -3,7 +3,7 @@
 
 variable "name" {
   description = "Name to assign the VM"
-  type = string
+  type        = string
 }
 
 variable "tags" {
@@ -15,13 +15,13 @@ variable "tags" {
 variable "vm_type" {
   description = "EC2 instance type"
   type        = string
-  default = "m5.4xlarge"
+  default     = "m5.4xlarge"
 }
 
 variable "cloud_init" {
   description = "Cloud init script to execute"
   type        = string
-  default = ""
+  default     = ""
 }
 
 variable "vm_admin" {
@@ -39,72 +39,72 @@ variable "ssh_public_key" {
 variable "security_group_ids" {
   description = "List of security group ids to associate with the EC2 instance"
   type        = list(string)
-  default = []
+  default     = []
 }
 
 variable "create_public_ip" {
   description = "Toggle the creation of a public EIP to be associated with the EC2 instance"
   type        = bool
-  default = false
+  default     = false
 }
 
 variable "data_disk_count" {
   description = "Number of disks to attach to the EC2 instance"
   type        = number
-  default = 0
+  default     = 0
 }
 
 variable "data_disk_size" {
   description = "Size of disk to attach to the EC2 instance in GiBs"
   type        = number
-  default = 128
+  default     = 128
 }
 
 variable "data_disk_type" {
   description = "The type of EBS volume for the data disk"
   type        = string
-  default = "gp2"
+  default     = "gp2"
 }
 
 variable "data_disk_availability_zone" {
   description = "The AZ where the EBS volume will exist"
   type        = string
-  default = ""
+  default     = ""
 }
 
 variable "data_disk_iops" {
   description = "The amount of IOPS to provision for the data disk"
   type        = number
-  default = 0
+  default     = 0
 }
 
 variable "os_disk_size" {
   description = "The size of the OS disk"
   type        = number
-  default = 64
+  default     = 64
 }
 
 variable "os_disk_type" {
   description = "The type of EBS volume for the OS disk"
   type        = string
-  default = "standard"
+  default     = "standard"
 }
 
 variable "os_disk_delete_on_termination" {
   description = "Delete disk on termination"
   type        = bool
-  default = true
+  default     = true
 }
 
 variable "os_disk_iops" {
   description = "The amount of IOPS to provision for the OS disk"
   type        = number
-  default = 0
+  default     = 0
 }
 
 variable "subnet_id" {
   description = "The VPC Subnet ID to launch in."
-  type = string
+  type        = string
 }
 
 variable "enable_ebs_encryption" {

--- a/modules/aws_vpc/main.tf
+++ b/modules/aws_vpc/main.tf
@@ -11,7 +11,7 @@ locals {
   existing_private_subnets  = local.existing_subnets && contains(keys(var.existing_subnet_ids), "private") ? (length(var.existing_subnet_ids["private"]) > 0 ? true : false) : false
   existing_database_subnets = local.existing_subnets && contains(keys(var.existing_subnet_ids), "database") ? (length(var.existing_subnet_ids["database"]) > 0 ? true : false) : false
 
-  public_subnets  = local.existing_public_subnets ? data.aws_subnet.public : aws_subnet.public
+  #  public_subnets  = local.existing_public_subnets ? data.aws_subnet.public : aws_subnet.public # not used keeping for ref
   private_subnets = local.existing_private_subnets ? data.aws_subnet.private : aws_subnet.private
 
 }

--- a/modules/aws_vpc/variables.tf
+++ b/modules/aws_vpc/variables.tf
@@ -15,8 +15,8 @@ variable "vpc_id" {
 
 variable "name" {
   description = "Prefix used when creating VPC resources"
-  type    = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "cidr" {

--- a/modules/aws_vpc/variables.tf
+++ b/modules/aws_vpc/variables.tf
@@ -9,10 +9,12 @@ variable "azs" {
 
 variable "vpc_id" {
   description = "Existing vpc id"
+  type        = string
   default     = null
 }
 
 variable "name" {
+  description = "Prefix used when creating VPC resources"
   type    = string
   default = null
 }
@@ -39,18 +41,6 @@ variable "existing_nat_id" {
   description = "Pre-existing VPC NAT Gateway id"
 }
 
-variable "enable_nat_gateway" {
-  description = "Should be true if you want to provision NAT Gateways for each of your private networks"
-  type        = bool
-  default     = true
-}
-
-variable "single_nat_gateway" {
-  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
-  type        = bool
-  default     = true
-}
-
 variable "enable_dns_hostnames" {
   description = "Should be true to enable DNS hostnames in the VPC"
   type        = bool
@@ -62,7 +52,6 @@ variable "enable_dns_support" {
   type        = bool
   default     = true
 }
-
 
 variable "tags" {
   description = "The tags to associate with your network and subnets."

--- a/modules/kubeconfig/output.tf
+++ b/modules/kubeconfig/output.tf
@@ -1,6 +1,7 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# tflint-ignore: terraform_standard_module_structure
 output "kube_config" {
   value = local_file.kubeconfig.content
 }

--- a/modules/kubeconfig/outputs.tf
+++ b/modules/kubeconfig/outputs.tf
@@ -1,7 +1,6 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# tflint-ignore: terraform_standard_module_structure
 output "kube_config" {
   value = local_file.kubeconfig.content
 }

--- a/modules/kubeconfig/variables.tf
+++ b/modules/kubeconfig/variables.tf
@@ -13,6 +13,7 @@ variable "namespace" {
 }
 
 variable "region" {
+  description = "AWS Region this cluster was provisioned in"
   type        = string
   default     = null
 }
@@ -24,17 +25,21 @@ variable "create_static_kubeconfig" {
 }
 
 variable "path" {
+  description = "Path to output the kubeconfig file"
   type        = string
 }
 
 variable "cluster_name" {
+  description = "Kubernetes cluster name"
   type        = string
 }
 
 variable "endpoint" {
+  description = "Kubernetes cluster endpoint"
   type        = string
 }
 
 variable "ca_crt" {
+  description = "Kubernetes CA certificate"
   type        = string
 }


### PR DESCRIPTION
### Changes

Updated the linting workflow config so that branches named with the path pattern (e.g. `feat/1078`) will also have pipeline automatically triggered for them.

Additionally, updated the linting workflow config so that `tflint` will now get run against the terraform files under `./modules`. In doing so additional formatting warnings appeared which was also resolved.

No functional changes, just formatting.

### Tests

| Scenario | Provider | K8s Version         | Notes                     |
|----------|----------|---------------------|---------------------------|
| 1        | AWS      | v1.26.7-eks-2d98532 | Infra creation smoke test |
| 2        | AWS      | v1.26.7-eks-2d98532 | Infra creation smoke test, retest |