### PR TITLE
feat: (IAC-367) Allow Ability To Specify Which Availability Zones the Subnets Get Created In

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -86,6 +86,7 @@ You can use `default_public_access_cidrs` to set a default range for all created
  | :--- | ---: | ---: | ---: | ---: |
  | vpc_cidr | Address space for the VPC | string | "192.168.0.0/16" | This variable is ignored when `vpc_id` is set (AKA bring your own VPC). |
  | subnets | Subnets to be created and their settings | map | See below for default values | This variable is ignored when `subnet_ids` is set (AKA bring your own subnets). All defined subnets must exist within the VPC address space. |
+ | subnet_azs | Configure specific AZs you want the subnets to created in. The values must be distinct | optional map | {} see below for an example | If not defined or if not enough zones are listed to match the definitions in `subnets`, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
 
 The default values for the subnets variable are as follows:
 
@@ -94,6 +95,18 @@ The default values for the subnets variable are as follows:
   "private" : ["192.168.0.0/18", "192.168.64.0/18"],
   "public" : ["192.168.129.0/25", "192.168.129.128/25"],
   "database" : ["192.168.128.0/25", "192.168.128.128/25"]
+}
+```
+
+Example for `subnet_azs`:
+
+The zones below define allow you to configure where each subnet in the map above will be created.
+e.g. for `"private" : ["192.168.0.0/18", "192.168.64.0/18"]`, the first subnet will be created in `us-east-2c` and the second in `us-east-2b` 
+```terraform
+subnet_azs = {
+  "private"  : ["us-east-2c", "us-east-2b"],
+  "public"   : ["us-east-2a", "us-east-2b"],
+  "database" : ["us-east-2a", "us-east-2b"]
 }
 ```
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -86,7 +86,7 @@ You can use `default_public_access_cidrs` to set a default range for all created
  | :--- | ---: | ---: | ---: | ---: |
  | vpc_cidr | Address space for the VPC | string | "192.168.0.0/16" | This variable is ignored when `vpc_id` is set (AKA bring your own VPC). |
  | subnets | Subnets to be created and their settings | map | See below for default values | This variable is ignored when `subnet_ids` is set (AKA bring your own subnets). All defined subnets must exist within the VPC address space. |
- | subnet_azs | Configure specific AZs you want the subnets to created in. The values must be distinct | optional map | {} see below for an example | If not defined or if not enough zones are listed to match the definitions in `subnets`, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
+ | subnet_azs | Configure specific AZs you want the subnets to created in. The values must be distinct | optional map | {} see below for an example | If not defined or if any keys are not defined, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
 
 The default values for the subnets variable are as follows:
 

--- a/locals.tf
+++ b/locals.tf
@@ -33,31 +33,9 @@ locals {
 
   # Generate list of AZ where created subnets should be placed
   # If not specified by the user replace with list of all AZs in a region
-  # If not enough regions provided, append with the list of all AZs in the region while retaining
-  # order of user provided list of regions
-  public_subnet_azs   = (
-  can(var.subnet_azs["public"]) ?
-    (length(var.subnet_azs["public"]) >= length(lookup(var.subnets, "public", [])) ?
-      var.subnet_azs["public"]
-      : distinct(concat(var.subnet_azs["public"], data.aws_availability_zones.available.names)))
-    : data.aws_availability_zones.available.names
-  )
-
-  private_subnet_azs   = (
-  can(var.subnet_azs["private"]) ?
-    (length(var.subnet_azs["private"]) >= length(lookup(var.subnets, "private", [])) ?
-      var.subnet_azs["private"]
-      : distinct(concat(var.subnet_azs["private"], data.aws_availability_zones.available.names)))
-    : data.aws_availability_zones.available.names
-  )
-
-  database_subnet_azs   = (
-  can(var.subnet_azs["database"]) ?
-    (length(var.subnet_azs["database"]) >= length(lookup(var.subnets, "database", [])) ?
-      var.subnet_azs["database"]
-      : distinct(concat(var.subnet_azs["database"], data.aws_availability_zones.available.names)))
-    : data.aws_availability_zones.available.names
-  )
+  public_subnet_azs   =   can(var.subnet_azs["public"]) ? var.subnet_azs["public"] : data.aws_availability_zones.available.names
+  private_subnet_azs  =   can(var.subnet_azs["private"]) ? var.subnet_azs["private"] : data.aws_availability_zones.available.names
+  database_subnet_azs =   can(var.subnet_azs["database"]) ? var.subnet_azs["database"] : data.aws_availability_zones.available.names
 
   ssh_public_key = (var.create_jump_vm || var.storage_type == "standard"
     ? file(var.ssh_public_key)

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,9 @@ module "vpc" {
   region              = var.location
   security_group_id   = local.security_group_id
   cidr                = var.vpc_cidr
-  azs                 = data.aws_availability_zones.available.names
+  public_subnet_azs = local.public_subnet_azs
+  private_subnet_azs = local.private_subnet_azs
+  database_subnet_azs = local.database_subnet_azs
   existing_subnet_ids = var.subnet_ids
   subnets             = var.subnets
   existing_nat_id     = var.nat_id

--- a/modules/aws_vpc/main.tf
+++ b/modules/aws_vpc/main.tf
@@ -78,8 +78,8 @@ resource "aws_subnet" "public" {
   count                   = local.existing_public_subnets ? 0 : length(var.subnets["public"])
   vpc_id                  = local.vpc_id
   cidr_block              = element(var.subnets["public"], count.index)
-  availability_zone       = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone       = length(regexall("^[a-z]{2}-", element(var.public_subnet_azs, count.index))) > 0 ? element(var.public_subnet_azs, count.index) : null
+  availability_zone_id    = length(regexall("^[a-z]{2}-", element(var.public_subnet_azs, count.index))) == 0 ? element(var.public_subnet_azs, count.index) : null
   map_public_ip_on_launch = var.map_public_ip_on_launch
 
   tags = merge(
@@ -87,7 +87,7 @@ resource "aws_subnet" "public" {
       "Name" = format(
         "%s-${var.public_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.public_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -123,7 +123,7 @@ resource "aws_route_table" "public" {
       "Name" = format(
         "%s-${var.public_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.public_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -173,15 +173,15 @@ resource "aws_subnet" "private" {
   count                = local.existing_private_subnets ? 0 : length(var.subnets["private"])
   vpc_id               = local.vpc_id
   cidr_block           = element(var.subnets["private"], count.index)
-  availability_zone    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone    = length(regexall("^[a-z]{2}-", element(var.private_subnet_azs, count.index))) > 0 ? element(var.private_subnet_azs, count.index) : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.private_subnet_azs, count.index))) == 0 ? element(var.private_subnet_azs, count.index) : null
 
   tags = merge(
     {
       "Name" = format(
         "%s-${var.private_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.private_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -203,7 +203,7 @@ resource "aws_route_table" "private" {
       "Name" = format(
         "%s-${var.private_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.private_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -217,15 +217,15 @@ resource "aws_subnet" "database" {
   count                = local.existing_database_subnets ? 0 : length(var.subnets["database"])
   vpc_id               = local.vpc_id
   cidr_block           = element(var.subnets["database"], count.index)
-  availability_zone    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone    = length(regexall("^[a-z]{2}-", element(var.database_subnet_azs, count.index))) > 0 ? element(var.database_subnet_azs, count.index) : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.database_subnet_azs, count.index))) == 0 ? element(var.database_subnet_azs, count.index) : null
 
   tags = merge(
     {
       "Name" = format(
         "%s-${var.database_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.database_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -257,7 +257,7 @@ resource "aws_eip" "nat" {
       "Name" = format(
         "%s-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.public_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -280,7 +280,7 @@ resource "aws_nat_gateway" "nat_gateway" {
       "Name" = format(
         "%s-%s",
         var.name,
-        element(var.azs, 0),
+        element(var.public_subnet_azs, 0),
       )
     },
     var.tags,

--- a/modules/aws_vpc/variables.tf
+++ b/modules/aws_vpc/variables.tf
@@ -1,11 +1,24 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-variable "azs" {
-  description = "A list of availability zones names or ids in the region"
+variable "public_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the public subnets"
   type        = list(string)
   default     = []
 }
+
+variable "private_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the private subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "database_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the database subnets"
+  type        = list(string)
+  default     = []
+}
+
 
 variable "vpc_id" {
   description = "Existing vpc id"

--- a/variables.tf
+++ b/variables.tf
@@ -365,6 +365,19 @@ variable "subnets" {
   }
 }
 
+variable "subnet_azs" {
+  description = "AZs you want the subnets to created in - This variable is ignored when `subnet_ids` is set (AKA bring your own subnets)."
+  type        = map(list(string))
+  default     = {}
+  nullable    = false
+
+  # We only support configuring the AZs for the public, private, and database subnet
+  validation {
+    condition     =  var.subnet_azs == {}  || alltrue([for subnet in keys(var.subnet_azs) : contains(["public", "private", "database"], subnet)])
+    error_message = "ERROR: only public, private, and database are the only keys allowed in the subnet_azs map"
+  }
+}
+
 variable "security_group_id" {
   description = "Pre-existing Security Group id. Leave blank to have one created."
   type        = string


### PR DESCRIPTION
### Changes

Allows users the ability to specify which AZs that the subnet gets created in with the new `subnet_azs` variable.

Similar to the existing `subnets` the map lets to set the name of the subnet along with zones will be used during creation

```
subnet_azs = {
  "private"  : ["us-east-2c", "us-east-2b"],
  "public"   : ["us-east-2a", "us-east-2b"],
  "database" : ["us-east-2a", "us-east-2b"]
}
```

So if your defined subnets as so in your .tfvars
```
{
  "private" : ["192.168.0.0/18", "192.168.64.0/18"],
  "public" : ["192.168.129.0/25", "192.168.129.128/25"],
  "database" : ["192.168.128.0/25", "192.168.128.128/25"]
}
```
for `"private" : ["192.168.0.0/18", "192.168.64.0/18"]`, the first subnet will be created in `us-east-2c` and the second in `us-east-2b`


This variable is entirely optional, and if not defined the code will perform a lookup to populate the zones just like the behavior in `viya4-iac-aws:7.2.1` and prior. If entire keys are not defined, the lookup will be used to populate those. ~~Also, If not enough zones are defined in the `subnet_azs` in comparison to the `subnets` map a the zone lookup will be done to make up the difference.~~ (behavior removed)


### Test

**WIP**