### PR TITLE
fix: (IAC-1174) Revert the Single AZ Changes

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -209,7 +209,6 @@ Custom policy:
 | autoscaling_enabled | Enable cluster autoscaling | bool | true | |
 | ssh_public_key | File name of public ssh key for jump and nfs VM | string | "~/.ssh/id_rsa.pub" | Required with `create_jump_vm=true` or `storage_type=standard` |
 | cluster_api_mode | Public or private IP for the cluster api| string|"public"|Valid Values: "public", "private" |
-| enable_multi_zone | Set to true to deploy EKS Node Pools in multiple availability zones | boolean | false | **WARNING**: changing this from true to false after infrastructure creation is destructive. If you have an existing Viya deployment in your cluster, following the [SAS Viya Platform Operations backup and restore documentation](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopsmigwlcm&docsetTarget=home.htm) is recommended before changing this. |
 
 ## Node Pools
 

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -32,9 +32,6 @@ default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""
 
-# This forces all worker nodes to run in a single zone and is required when deploying a 'singlestore' node pool.
-enable_multi_zone = false
-
 ## General
 efs_performance_mode = "maxIO"
 storage_type         = "standard"

--- a/main.tf
+++ b/main.tf
@@ -97,13 +97,10 @@ module "eks" {
   cluster_endpoint_public_access       = var.cluster_api_mode == "public" ? true : false
   cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
 
-  # AWS requires two or more subnets in different Availability Zones for your cluster's control plane.
-  control_plane_subnet_ids = module.vpc.private_subnets
-  # Specifies the list of subnets in which the worker nodes of the EKS cluster will be launched.
-  subnet_ids               = var.enable_multi_zone ? module.vpc.private_subnets : [module.vpc.private_subnets[0]]
-  vpc_id                   = module.vpc.vpc_id
-  tags                     = local.tags
-  enable_irsa              = var.autoscaling_enabled
+  subnet_ids  = module.vpc.private_subnets
+  vpc_id      = module.vpc.vpc_id
+  tags        = local.tags
+  enable_irsa = var.autoscaling_enabled
   ################################################################################
   # Cluster Security Group
   ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -232,12 +232,6 @@ variable "default_nodepool_metadata_http_put_response_hop_limit" {
   default     = 1
 }
 
-variable "enable_multi_zone" {
-  description = "Set to true to deploy EKS Node Pools in multiple availability zones."
-  type        = bool
-  default     = false
-}
-
 ## Dynamic node pool config
 variable "node_pools" {
   description = "Node Pool Definitions."


### PR DESCRIPTION
### Changes:

Reverts the EKS Single AZ changes from #234


### Tests

| Scenario | Provider | Summary     | From                   | To  | K8s Version         | Order  | Cadence   | Notes                                     |
|----------|----------|-------------|------------------------|-----|---------------------|--------|-----------|-------------------------------------------|
| 1        | AWS      | Revert #234 | viya4-iac-aws: PR #237 | N/A | v1.26.8-eks-43840fb | * | fast:2020 | previous multi-az behavior observed again |