### PR TITLE
feat!: (IAC-1174) EKS Node Pool Subnets to use Single AZ by Default

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -114,9 +114,10 @@ The default values for the subnets variable are as follows:
 
 ```yaml
 {
-  "private" : ["192.168.0.0/18", "192.168.64.0/18"],
-  "public" : ["192.168.129.0/25", "192.168.129.128/25"],
-  "database" : ["192.168.128.0/25", "192.168.128.128/25"]
+    "private" : ["192.168.0.0/18"], # multi-zonal cluster is created by adding additional subnets here
+    "control_plane" : ["192.168.130.0/28", "192.168.130.16/28"], # AWS recommends at least 16 IP addresses per subnet
+    "public" : ["192.168.129.0/25", "192.168.129.128/25"],
+    "database" : ["192.168.128.0/25", "192.168.128.128/25"]
 }
 ```
 
@@ -142,7 +143,8 @@ Example `subnet_ids` variable:
 ```terraform
 subnet_ids = {
   "public" : ["existing-public-subnet-id1", "existing-public-subnet-id2"],
-  "private" : ["existing-private-subnet-id1", "existing-private-subnet-id2"],
+  "private" : ["existing-private-subnet-id1"],
+  "control_plane" : ["existing-control-plane-subnet-id1", "existing-control-plane-subnet-id2"],
   "database" : ["existing-database-subnet-id1","existing-database-subnet-id2"]
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -101,10 +101,13 @@ module "eks" {
   cluster_endpoint_public_access       = var.cluster_api_mode == "public" ? true : false
   cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
 
-  subnet_ids  = module.vpc.private_subnets
-  vpc_id      = module.vpc.vpc_id
-  tags        = local.tags
-  enable_irsa = var.autoscaling_enabled
+  # AWS requires two or more subnets in different Availability Zones for your cluster's control plane.
+  control_plane_subnet_ids = module.vpc.control_plane_subnets
+  # Specifies the list of subnets in which the worker nodes of the EKS cluster will be launched.
+  subnet_ids               = module.vpc.private_subnets
+  vpc_id                   = module.vpc.vpc_id
+  tags                     = local.tags
+  enable_irsa              = var.autoscaling_enabled
   ################################################################################
   # Cluster Security Group
   ################################################################################

--- a/modules/aws_vpc/outputs.tf
+++ b/modules/aws_vpc/outputs.tf
@@ -45,6 +45,11 @@ output "database_subnets" {
   value       = local.existing_database_subnets ? data.aws_subnet.database[*].id : local.database_subnets[*].id
 }
 
+output "control_plane_subnets" {
+  description = "List of IDs of control plane subnets"
+  value       = local.existing_control_plane_subnets ? data.aws_subnet.control_plane[*].id : local.control_plane_subnets[*].id
+}
+
 output "nat_public_ips" {
   description = "List of public Elastic IPs created for AWS NAT Gateway"
   value       = var.existing_nat_id == null ? local.create_nat_gateway ? aws_eip.nat[*].public_ip : null : data.aws_nat_gateway.nat_gateway[*].public_ip

--- a/modules/aws_vpc/variables.tf
+++ b/modules/aws_vpc/variables.tf
@@ -89,6 +89,12 @@ variable "database_subnet_suffix" {
   default     = "db"
 }
 
+variable "control_plane_subnet_suffix" {
+  description = "Suffix to append to control plane subnets name"
+  type        = string
+  default     = "control-plane"
+}
+
 variable "map_public_ip_on_launch" {
   description = "Should be false if you do not want to auto-assign public IP on launch"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -356,7 +356,8 @@ variable "subnet_ids" {
   # Example:
   # subnet_ids = {  # only needed if using pre-existing subnets
   #   "public" : ["existing-public-subnet-id1", "existing-public-subnet-id2"],
-  #   "private" : ["existing-private-subnet-id1", "existing-private-subnet-id2"],
+  #   "private" : ["existing-private-subnet-id1"],
+  #   "control_plane" : ["existing-control-plane-subnet-id1", "existing-control-plane-subnet-id2"],
   #   "database" : ["existing-database-subnet-id1", "existing-database-subnet-id2"] # only when 'create_postgres=true'
   # }
 }
@@ -371,7 +372,8 @@ variable "subnets" {
   description = "Subnets to be created and their settings - This variable is ignored when `subnet_ids` is set (AKA bring your own subnets)."
   type        = map(list(string))
   default = {
-    "private" : ["192.168.0.0/18", "192.168.64.0/18"],
+    "private" : ["192.168.0.0/18"], # multi-zonal cluster is created by adding additional subnets here
+    "control_plane" : ["192.168.100.0/28", "192.168.100.16/28"], # AWS recommends at least 16 IP addresses per subnet
     "public" : ["192.168.129.0/25", "192.168.129.128/25"],
     "database" : ["192.168.128.0/25", "192.168.128.128/25"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -373,7 +373,7 @@ variable "subnets" {
   type        = map(list(string))
   default = {
     "private" : ["192.168.0.0/18"], # multi-zonal cluster is created by adding additional subnets here
-    "control_plane" : ["192.168.100.0/28", "192.168.100.16/28"], # AWS recommends at least 16 IP addresses per subnet
+    "control_plane" : ["192.168.130.0/28", "192.168.130.16/28"], # AWS recommends at least 16 IP addresses per subnet
     "public" : ["192.168.129.0/25", "192.168.129.128/25"],
     "database" : ["192.168.128.0/25", "192.168.128.128/25"]
   }


### PR DESCRIPTION

### Changes

In order to line up with the recommendations from the SAS Viya Platform Operations documentation we are updating the code base so that when EKS node groups are created they will be placed in a single-AZ rather than spanning over multiple-AZs. This feature is controlled by an update to the `subnets` and `subnets_ids` map by adding a new key `control_plane` to allow finer control for subnet assignment. CIDRs/IDs added to the `control_plane` list will be used for only for the control plane when creating the EKS cluster, [AWS requires](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) that there are at least two CIDR ranges provided in different AZs, both ranges must have at least 6 addresses. The existing `private` CIDR list will now no longer be shared with the control plane and instead only used for the worker nodes during subnet assignment, we changed the default value of this list to only have 1 CIDR range from a single AZ to meet our single-AZ recommendation from the SAS Viya Platform Operations documentation.

Relevant SAS Viya Platform documentation for AWS Cluster Requirements:
https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n098rczq46ffjfn1xbgfzahytnmx.htm#p0vx68bmb3fs88n12d73wwxpsnhu

This is considered a breaking change since users who initially created their infrastructure with viya4-iac-aws:7.2.1 or earlier will need to destroy their infrastructure if they want to adopt this latest version. This is due to a limitation of the [Terraform AWS EKS module](https://github.com/terraform-aws-modules/terraform-aws-eks), if a configuration value that AWS does not allow you to change post-resource creation (in this case updating the subnets of an EKS control plane) and requires the cluster to be deleted/recreated, the module will instead throw an error since it does not handle performing that recreate operation for you.

Relevant GitHub Issue from `terraform-aws-modules/terraform-aws-eks`: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2061

The current recommendation for users who want to use this latest release and created their infrastructure for a Viya deployment with viya4-iac-aws:7.2.1 or earlier is to:
1. Follow the SAS Viya Platform Operation [backup and restore documentation](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopsmigwlcm&docsetTarget=home.htm) to perform a full backup of their environment.
2. Uninstall the SAS Viya deployment and destroy the infrastructure using the version of viya4-iac-aws you initially deployed with.
3. Recreate your infrastructure using the latest version of viya4-iac-aws
4. Follow the SAS Viya Platform Operation [backup and restore documentation](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopsmigwlcm&docsetTarget=home.htm) to restore your environment.


### Tests

| Scenario | Provider | Summary                                               | K8s Version          | Order  | Cadence   | Notes                                                                                    |
|----------|----------|-------------------------------------------------------|----------------------|--------|-----------|------------------------------------------------------------------------------------------|
| 1        | AWS      | Single-AZ OOTB                                        | v1.26.9-eks-f8587cb  | ****** | fast:2020 | this is the new default                                                                  |
| 2        | AWS      | Multi-AZ OOTB                                         | v1.26.9-eks-f8587cb  | ****** | fast:2020 | performed by manually adding second subnet in subnets.private                            |
| 3        | AWS      | Multi-AZ (7.2.1) > Stop Viya > Single-AZ > Start Viya | v1.26.9-eks-f8587cb | ****** | fast:2020 | Expected failure, https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2061 |
| 4        | AWS      | Single-AZ BYO (type 2)                                | v1.26.10-eks-4f4795d | ****** | fast:2020 | pods all running                                                                         |
