### PR TITLE
feat: (IAC-367) Allow Ability To Specify Which Availability Zones the Subnets Get Created In

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -109,7 +109,7 @@ You can also use `default_private_access_cidrs` to apply the same CIDR range to 
 | :--- | ---: | ---: | ---: | ---: |
 | vpc_cidr | Address space for the VPC | string | "192.168.0.0/16" | This variable is ignored when `vpc_id` is set (AKA bring your own VPC). |
 | subnets | Subnets to be created and their settings | map | See below for default values | This variable is ignored when `subnet_ids` is set (AKA bring your own subnets). All defined subnets must exist within the VPC address space. |
-| subnet_azs | Configure specific AZs you want the subnets to be created in. The values must be distinct | optional map | {} see below for an example | If not defined or if any keys are not defined, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
+| subnet_azs | Configure specific AZs you want the subnets to be created in. The values must be distinct | optional map | {} see below for an example | If you wish for the codebase to lookup a list of AZs for you: either don't define subnet_azs to lookup AZs for all subnets, or omit the key for a specific subnet in the map to perform a lookup for it. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
 
 The default values for the subnets variable are as follows:
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -105,10 +105,11 @@ You can also use `default_private_access_cidrs` to apply the same CIDR range to 
 | vm_private_access_cidrs | IP address ranges that are allowed to access private IP based Jump or NFS Server VMs.| list of strings | | Opens port 22 for SSH access to the jump server and/or NFS VM by adding Ingress Rule on the Workers Security Group. Only used with `create_jump_public_ip=false` or `create_nfs_public_ip=false`. |
 
 ## Networking
- | Name | Description | Type | Default | Notes |
- | :--- | ---: | ---: | ---: | ---: |
- | vpc_cidr | Address space for the VPC | string | "192.168.0.0/16" | This variable is ignored when `vpc_id` is set (AKA bring your own VPC). |
- | subnets | Subnets to be created and their settings | map | See below for default values | This variable is ignored when `subnet_ids` is set (AKA bring your own subnets). All defined subnets must exist within the VPC address space. |
+| Name | Description | Type | Default | Notes |
+| :--- | ---: | ---: | ---: | ---: |
+| vpc_cidr | Address space for the VPC | string | "192.168.0.0/16" | This variable is ignored when `vpc_id` is set (AKA bring your own VPC). |
+| subnets | Subnets to be created and their settings | map | See below for default values | This variable is ignored when `subnet_ids` is set (AKA bring your own subnets). All defined subnets must exist within the VPC address space. |
+| subnet_azs | Configure specific AZs you want the subnets to created in. The values must be distinct | optional map | {} see below for an example | If not defined or if any keys are not defined, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
 
 The default values for the subnets variable are as follows:
 
@@ -118,6 +119,20 @@ The default values for the subnets variable are as follows:
     "control_plane" : ["192.168.130.0/28", "192.168.130.16/28"], # AWS recommends at least 16 IP addresses per subnet
     "public" : ["192.168.129.0/25", "192.168.129.128/25"],
     "database" : ["192.168.128.0/25", "192.168.128.128/25"]
+}
+```
+
+Example for `subnet_azs`:
+
+The zones below define allow you to configure where each subnet in the map above will be created.
+e.g. Looking at the example `subnets` map above, for `"control_plane" : ["192.168.130.0/28", "192.168.130.16/28"]`, the first subnet will be created in `us-east-2c` and the second in `us-east-2b` 
+
+```terraform
+subnet_azs = {
+  "private"       : ["us-east-2c"],
+  "control_plane" : ["us-east-2c", "us-east-2b"],
+  "public"        : ["us-east-2a", "us-east-2b"],
+  "database"      : ["us-east-2a", "us-east-2b"]
 }
 ```
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -124,7 +124,7 @@ The default values for the subnets variable are as follows:
 
 Example for `subnet_azs`:
 
-The zones below define allow you to configure where each subnet in the map above will be created.
+The zones defined below allow you to configure where each subnet in the map above will be created.
 e.g. Looking at the example `subnets` map above, for `"control_plane" : ["192.168.130.0/28", "192.168.130.16/28"]`, the first subnet will be created in `us-east-2c` and the second in `us-east-2b` 
 
 ```terraform

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -109,7 +109,7 @@ You can also use `default_private_access_cidrs` to apply the same CIDR range to 
 | :--- | ---: | ---: | ---: | ---: |
 | vpc_cidr | Address space for the VPC | string | "192.168.0.0/16" | This variable is ignored when `vpc_id` is set (AKA bring your own VPC). |
 | subnets | Subnets to be created and their settings | map | See below for default values | This variable is ignored when `subnet_ids` is set (AKA bring your own subnets). All defined subnets must exist within the VPC address space. |
-| subnet_azs | Configure specific AZs you want the subnets to created in. The values must be distinct | optional map | {} see below for an example | If not defined or if any keys are not defined, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
+| subnet_azs | Configure specific AZs you want the subnets to be created in. The values must be distinct | optional map | {} see below for an example | If not defined or if any keys are not defined, the code will perform a lookup to get a list of AZs in your selected region. This variable is ignored when `subnet_ids` is set (AKA bring your own subnets).|
 
 The default values for the subnets variable are as follows:
 

--- a/locals.tf
+++ b/locals.tf
@@ -40,6 +40,13 @@ locals {
   nfs_vm_subnet    = var.create_nfs_public_ip ? module.vpc.public_subnets[0] : module.vpc.private_subnets[0]
   nfs_vm_subnet_az = var.create_nfs_public_ip ? module.vpc.public_subnet_azs[0] : module.vpc.private_subnet_azs[0]
 
+  # Generate list of AZ where created subnets should be placed
+  # If not specified by the user replace with list of all AZs in a region
+  public_subnet_azs        =  can(var.subnet_azs["public"]) ? var.subnet_azs["public"] : data.aws_availability_zones.available.names
+  private_subnet_azs       =  can(var.subnet_azs["private"]) ? var.subnet_azs["private"] : data.aws_availability_zones.available.names
+  database_subnet_azs      =  can(var.subnet_azs["database"]) ? var.subnet_azs["database"] : data.aws_availability_zones.available.names
+  control_plane_subnet_azs =  can(var.subnet_azs["control_plane"]) ? var.subnet_azs["control_plane"] : data.aws_availability_zones.available.names
+
   ssh_public_key = (var.create_jump_vm || var.storage_type == "standard"
     ? file(var.ssh_public_key)
     : null

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,10 @@ module "vpc" {
   cluster_security_group_id     = var.cluster_security_group_id
   workers_security_group_id     = var.workers_security_group_id
   cidr                          = var.vpc_cidr
-  azs                           = data.aws_availability_zones.available.names
+  public_subnet_azs             = local.public_subnet_azs
+  private_subnet_azs            = local.private_subnet_azs
+  database_subnet_azs           = local.database_subnet_azs
+  control_plane_subnet_azs      = local.control_plane_subnet_azs
   existing_subnet_ids           = var.subnet_ids
   subnets                       = var.subnets
   existing_nat_id               = var.nat_id

--- a/modules/aws_vpc/main.tf
+++ b/modules/aws_vpc/main.tf
@@ -93,8 +93,8 @@ resource "aws_subnet" "public" {
   count                   = local.existing_public_subnets ? 0 : local.create_subnets ? length(var.subnets["public"]) : 0
   vpc_id                  = local.vpc_id
   cidr_block              = element(var.subnets["public"], count.index)
-  availability_zone       = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone       = length(regexall("^[a-z]{2}-", element(var.public_subnet_azs, count.index))) > 0 ? element(var.public_subnet_azs, count.index) : null
+  availability_zone_id    = length(regexall("^[a-z]{2}-", element(var.public_subnet_azs, count.index))) == 0 ? element(var.public_subnet_azs, count.index) : null
   map_public_ip_on_launch = var.map_public_ip_on_launch
 
   tags = merge(
@@ -102,7 +102,7 @@ resource "aws_subnet" "public" {
       "Name" = format(
         "%s-${var.public_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.public_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -138,7 +138,7 @@ resource "aws_route_table" "public" {
       "Name" = format(
         "%s-${var.public_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.public_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -194,15 +194,15 @@ resource "aws_subnet" "private" {
   count                = local.existing_private_subnets ? 0 : length(var.subnets["private"])
   vpc_id               = local.vpc_id
   cidr_block           = element(var.subnets["private"], count.index)
-  availability_zone    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone    = length(regexall("^[a-z]{2}-", element(var.private_subnet_azs, count.index))) > 0 ? element(var.private_subnet_azs, count.index) : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.private_subnet_azs, count.index))) == 0 ? element(var.private_subnet_azs, count.index) : null
 
   tags = merge(
     {
       "Name" = format(
         "%s-${var.private_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.private_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -224,7 +224,7 @@ resource "aws_route_table" "private" {
       "Name" = format(
         "%s-${var.private_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.private_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -238,15 +238,15 @@ resource "aws_subnet" "database" {
   count                = local.existing_database_subnets ? 0 : local.create_subnets ? length(var.subnets["database"]) : 0
   vpc_id               = local.vpc_id
   cidr_block           = element(var.subnets["database"], count.index)
-  availability_zone    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone    = length(regexall("^[a-z]{2}-", element(var.database_subnet_azs, count.index))) > 0 ? element(var.database_subnet_azs, count.index) : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.database_subnet_azs, count.index))) == 0 ? element(var.database_subnet_azs, count.index) : null
 
   tags = merge(
     {
       "Name" = format(
         "%s-${var.database_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.database_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -275,15 +275,15 @@ resource "aws_subnet" "control_plane" {
   count                = local.existing_control_plane_subnets ? 0 : length(var.subnets["control_plane"])
   vpc_id               = local.vpc_id
   cidr_block           = element(var.subnets["control_plane"], count.index)
-  availability_zone    = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone    = length(regexall("^[a-z]{2}-", element(var.control_plane_subnet_azs, count.index))) > 0 ? element(var.control_plane_subnet_azs, count.index) : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", element(var.control_plane_subnet_azs, count.index))) == 0 ? element(var.control_plane_subnet_azs, count.index) : null
 
   tags = merge(
     {
       "Name" = format(
         "%s-${var.control_plane_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.control_plane_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -300,7 +300,7 @@ resource "aws_eip" "nat" {
       "Name" = format(
         "%s-%s",
         var.name,
-        element(var.azs, count.index),
+        element(var.public_subnet_azs, count.index),
       )
     },
     var.tags,
@@ -323,7 +323,7 @@ resource "aws_nat_gateway" "nat_gateway" {
       "Name" = format(
         "%s-%s",
         var.name,
-        element(var.azs, 0),
+        element(var.public_subnet_azs, 0),
       )
     },
     var.tags,

--- a/modules/aws_vpc/variables.tf
+++ b/modules/aws_vpc/variables.tf
@@ -1,8 +1,26 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-variable "azs" {
-  description = "A list of availability zones names or ids in the region"
+variable "public_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the public subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the private subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "control_plane_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the control plane subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "database_subnet_azs" {
+  description = "A list of availability zones names or ids in the region for creating the database subnets"
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -379,6 +379,18 @@ variable "subnets" {
   }
 }
 
+variable "subnet_azs" {
+  description = "AZs you want the subnets to created in - This variable is ignored when `subnet_ids` is set (AKA bring your own subnets)."
+  type        = map(list(string))
+  default     = {}
+  nullable    = false
+
+  # We only support configuring the AZs for the public, private, control_plane, and database subnet
+  validation {
+    condition     =  var.subnet_azs == {}  || alltrue([for subnet in keys(var.subnet_azs) : contains(["public", "private", "control_plane", "database"], subnet)])
+    error_message = "ERROR: only public, private, control_plane, and database are the only keys allowed in the subnet_azs map"
+  }
+}
 variable "security_group_id" {
   description = "Pre-existing Security Group id. Leave blank to have one created."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -388,7 +388,7 @@ variable "subnet_azs" {
   # We only support configuring the AZs for the public, private, control_plane, and database subnet
   validation {
     condition     =  var.subnet_azs == {}  || alltrue([for subnet in keys(var.subnet_azs) : contains(["public", "private", "control_plane", "database"], subnet)])
-    error_message = "ERROR: only public, private, control_plane, and database are the only keys allowed in the subnet_azs map"
+    error_message = "ERROR: public, private, control_plane, and database are the only keys allowed in the subnet_azs map"
   }
 }
 variable "security_group_id" {


### PR DESCRIPTION
### Changes

Allows users the ability to specify which AZs that the subnet gets created in with the new `subnet_azs` variable.

Similar to the existing `subnets` the map lets to set the name of the subnet along with zones will be used during creation

```terraform
subnet_azs = {
  "private"       : ["us-east-2c"],
  "control_plane" : ["us-east-2c", "us-east-2b"],
  "public"        : ["us-east-2a", "us-east-2b"],
  "database"      : ["us-east-2a", "us-east-2b"]
}
```

So if your defined subnets as so in your .tfvars

```terraform
{
    "private" : ["192.168.0.0/18"], 
    "control_plane" : ["192.168.130.0/28", "192.168.130.16/28"],
    "public" : ["192.168.129.0/25", "192.168.129.128/25"],
    "database" : ["192.168.128.0/25", "192.168.128.128/25"]
}
```
for `"control_plane" : ["192.168.130.0/28", "192.168.130.16/28"]`, the first subnet will be created in `us-east-2c` and the second in `us-east-2b`


This variable is entirely optional, and if not defined the code will perform a lookup to populate the zones just like the behavior in `viya4-iac-aws:7.2.1` and prior. If entire keys are not defined, the lookup will be used to populate those.


### Tests

| Scenario | Provider | Summary                                  | K8s Version          | Order  | Cadence   | 
|----------|----------|------------------------------------------|----------------------|--------|-----------|
| 1        | AWS      | OOTB, subnet_azs not defined             | v1.26.10-eks-4f4795d | ****** | fast:2020 | 
| 2        | AWS      | OOTB, all keys in subnet_azs customized  | v1.26.10-eks-4f4795d | ******| fast:2020 | 
| 3        | AWS      | OOTB, partial keys in subnet_azs defined | v1.26.10-eks-4f4795d | ****** | fast:2020 | 

**Validation Scenarios**

In all cases subnet was left as the default value: https://github.com/sassoftware/viya4-iac-aws/blob/staging/variables.tf#L371

| Scenario | Summary                                                | Behavior                      |
|----------|--------------------------------------------------------|-------------------------------|
| 1        | subnet_azs not defined, defaults to {}                 | Valid, no error message       |
| 2        | subnet_azs fully defined, correct entries per each key | Valid, no error message       |
| 3        | subnet_azs defined, private key omitted                | Valid, no error message       |
| 4        | subnet_azs defined, control_plane key omitted          | Valid, no error message       |
| 5        | subnet_azs defined, database key not enough entries    | Invalid, error message thrown |
| 6        | subnet_azs defined, public key not enough entries      | Invalid, error message thrown |
| 7        | subnet_azs defined, control_plane key extra entries    | Valid, no error message       |
