### PR TITLE
Suggestion: Don't create final DB snapshot when destroying Amazon RDS instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -236,8 +236,9 @@ module "postgresql" {
 
   vpc_security_group_ids = [local.security_group_id, local.workers_security_group_id]
 
-  maintenance_window = "Mon:00:00-Mon:03:00"
-  backup_window      = "03:00-06:00"
+  maintenance_window  = "Mon:00:00-Mon:03:00"
+  backup_window       = "03:00-06:00"
+  skip_final_snapshot = true
 
   # disable backups to create DB faster
   backup_retention_period = each.value.backup_retention_days


### PR DESCRIPTION
While using viya4-iac-aws to provision an Amazon RDS instance, I noticed that a database snapshot is created when doing a 'terraform destroy'. The user doesn't really have any way to know that this snapshot is created, and it will persist indefinitely until the user manual deletes it. Personally, when doing a 'terraform destroy', I would expect all resources to be removed, or at least some indication that something is being left behind. 

It looks like the **rds** module provides a **skip_final_snapshot** flag which can be used to control this behavior. This PR simply sets this flag to **true** by default rather than **false**.