### PR TITLE
chore: (IAC-1227) enable terraform_deprecated_lookup

### DIFF
--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -130,10 +130,3 @@ rule "terraform_unused_required_providers" {
 rule "terraform_workspace_remote" {
   enabled = true
 }
-
-# Disallow deprecated lookup function usage without a default.
-# temporarily disabling for the 8.0.0 release, will fix in following release.
-# See IAC-1227
-rule "terraform_deprecated_lookup" {
-  enabled = false
-}

--- a/main.tf
+++ b/main.tf
@@ -44,14 +44,14 @@ resource "kubernetes_config_map" "sas_iac_buildinfo" {
   }
 
   data = {
-    git-hash    = lookup(data.external.git_hash.result, "git-hash")
+    git-hash = data.external.git_hash.result["git-hash"]
     timestamp   = chomp(timestamp())
     iac-tooling = var.iac_tooling
     terraform   = <<EOT
-version: ${lookup(data.external.iac_tooling_version.result, "terraform_version")}
-revision: ${lookup(data.external.iac_tooling_version.result, "terraform_revision")}
-provider-selections: ${lookup(data.external.iac_tooling_version.result, "provider_selections")}
-outdated: ${lookup(data.external.iac_tooling_version.result, "terraform_outdated")}
+version: ${data.external.iac_tooling_version.result["terraform_version"]}
+revision: ${data.external.iac_tooling_version.result["terraform_revision"]}
+provider-selections: ${data.external.iac_tooling_version.result["provider_selections"]}
+outdated: ${data.external.iac_tooling_version.result["terraform_outdated"]}
 EOT
   }
 }


### PR DESCRIPTION
### Changes

Update the code to re-enable `terraform_deprecated_lookup` linting rules and resolve any warnings

doc: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_deprecated_lookup.md

### Tests

Created infrastructure and ensured the `sas-iac-buildinfo` was present

```
viya4-iac-aws$ kubectl get cm -n kube-system sas-iac-buildinfo -o yaml
apiVersion: v1
data:
  git-hash: f0037f49843ca9fad9bcf9bae6853c90750303e9
  iac-tooling: docker
  terraform: |
    version: "1.4.5"
    revision: null
    provider-selections: {"registry.terraform.io/hashicorp/aws":"5.4.0","registry.terraform.io/hashicorp/cloudinit":"2.3.2","registry.terraform.io/hashicorp/external":"2.3.1","registry.terraform.io/hashicorp/kubernetes":"2.20.0","registry.terraform.io/hashicorp/local":"2.4.0","registry.terraform.io/hashicorp/null":"3.2.1","registry.terraform.io/hashicorp/random":"3.5.1","registry.terraform.io/hashicorp/tls":"4.0.4"}
    outdated: false
  timestamp: "2023-11-27T19:52:03Z"
immutable: false
kind: ConfigMap
metadata:
  creationTimestamp: "2023-11-27T19:52:08Z"
  name: sas-iac-buildinfo
  namespace: kube-system
  resourceVersion: "894"
  uid: b706ad1e-2e5b-4685-ad2a-89d379b791b6
```