### PR TITLE
fix: (IAC-1240) cluster_api_mode=public requires ingress rules for API server's private IP address

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -29,7 +29,7 @@ locals {
 
   cluster_endpoint_public_access_cidrs = var.cluster_api_mode == "private" ? [] : (var.cluster_endpoint_public_access_cidrs == null ? local.default_public_access_cidrs : var.cluster_endpoint_public_access_cidrs)
 
-  cluster_endpoint_private_access_cidrs = var.cluster_api_mode == "public" ? [] : var.cluster_endpoint_private_access_cidrs == null ? distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs)) : distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs, var.cluster_endpoint_private_access_cidrs)) # tflint-ignore: terraform_unused_declarations
+  cluster_endpoint_private_access_cidrs = var.cluster_endpoint_private_access_cidrs == null ? distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs)) : distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs, var.cluster_endpoint_private_access_cidrs)) # tflint-ignore: terraform_unused_declarations
 
   vpc_endpoint_private_access_cidrs = var.vpc_endpoint_private_access_cidrs == null ? distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs)) : distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs, var.vpc_endpoint_private_access_cidrs))
 


### PR DESCRIPTION
Using a byo_network_scenario=2 configuration when `cluster_api_mode=public` and where the IaC client VM is running within the byo_network configured VPC, the IaC client VM requires connectivity to the EKS cluster API server endpoint as it does for other configurations. The `cluster_endpoint_private_access_cidrs` variable can be used to specify either an IP address or CIDR range for the IaC VM client, but the existing behavior prevents the creation of the required security group ingress rule when `cluster_api_mode=public`. Given that we'd like the IaC client VM network configuration described above to access the EKS cluster API server endpoint, allowing values to be set for `cluster_endpoint_private_access_cidrs` and creating the SG ingress rule should be allowed with `cluster_api_mode` set to public or private.

### Changes
- Allow the customer to specify values for cluster_endpoint_private_access_cidrs and have those values create the expected EKS cluster SG ingress rule regardless of the cluster_api_mode.

### Tests
| Scenario | byo_network_scenario | viya4-iac-aws version | cluster_api_mode | cluster_endpoint_private_access_cidrs | Notes |
|-|-|-|-|-|-|
| 1 | 2 | 8.0.0-staging | public | set to private IP address of IaC client VM | IaC client VM is located in a public subnet of the byo_network_scenario VPC. See terraform-input-iac140.tfvars in zip file, eks cluster SG has no ingress rule for IaC client VM, IaC unable to access EKS cluster api server endpoint, IaC fails with IAC-1240 reported error |
| 2 | 2 | 8.0.0-staging +iac-aws PRs 246,247,248 | public |set to private IP address of IaC client VM | same IaC client VM is located in a public subnet of the byo_network_scenario VPC. See terraform-input-iac140.tfvars in zip file, eks cluster SG has ingress rule for IaC client VM, IaC can access EKS cluster api server endpoint and terraform apply completes successfully |
| 3 | 0 | 8.0.0-staging +iac-aws PRs 246,247,248 | public | not set | non-byo_network scenario, IaC can access EKS cluster api server endpoint and terraform apply completes successfully |


### Background information from Phil regarding his proposed change to ingress rule creation.

For IaC-1240, I found that by changing line 32 in locals.tf of the staging branch:

> cluster_endpoint_private_access_cidrs = var.cluster_api_mode == "public" ? [] : var.cluster_endpoint_private_access_cidrs == null ? distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs)) : distinct(concat(module.vpc.public_subnet_cidrs, module.vpc.private_subnet_cidrs, local.default_private_access_cidrs, var.cluster_endpoint_private_access_cidrs)) # tflint-ignore: terraform_unused_declarations

 
and dropping the first conditional:

>  var.cluster_api_mode == "public" ? []

 then the code correctly populates IaC’s cluster security group using CIDRs specified in cluster_endpoint_private_access_cidrs

 That conditional block “if cluster_api_mode == public then set to null” logic is wiping out any values specified in the _cluster_endpoint_private_access_cidrs_ input variable (perhaps assuming they are a user error?) which then translates to the  ingress rule creation failing when the cluster_security_group is created.

If cluster_api_mode meant public without private, this would be correct behavior, however as is, we offer only two API server modes in the code:  public OR public/private.
