### PR TITLE
chore: (IAC-1190) Bump container test expected versions for terraform and aws-cli

### DIFF
--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -17,14 +17,14 @@ commandTests:
   - name: "terraform version"
     command: "terraform"
     args: ["--version"]
-    expectedOutput: ["Terraform v1.4.5"]
+    expectedOutput: ["Terraform v1.6.3"]
   - name: "aws-cli version"
     command: "sh"
     args:
       - -c
       - |
         aws --version
-    expectedOutput: ["aws-cli/2.11.21"]
+    expectedOutput: ["aws-cli/2.13.33"]
 
 metadataTest:
   workdir: "/viya4-iac-aws"


### PR DESCRIPTION
### Changes
Terraform binary and awc-cli version updates in PR #246 required version bumps in container-structure-test.yaml file for github action executed for PRs targeting the main branch.
