### PR TITLE
chore: (IAC-1292) remove terraform_documented_outputs explicit definition

### DIFF
--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -37,11 +37,6 @@ rule "terraform_deprecated_interpolation" {
   enabled = true
 }
 
-# Disallow output declarations without description.
-rule "terraform_documented_outputs" {
-  enabled = true
-}
-
 # Disallow variable declarations without description.
 rule "terraform_documented_variables" {
   enabled = true


### PR DESCRIPTION
### Changes

Remove the explicit definition of `terraform_documented_outputs`. This `tflint` rule is enabled by default so we can remove it from `.tflint.hcl` to clean things up.

