### PR TITLE
feat: (IAC-1265) AWS - Support K8s 1.28 in Viya 2024.02

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.13.33
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.26.10
+ARG KUBECTL_VERSION=1.27.9
 
 WORKDIR /viya4-iac-aws
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.6.3
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.26.10
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.27.9
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.13.33
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -257,7 +257,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | true | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.26" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.27" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 1
 default_nodepool_vm_type     = "m5.large"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.26"
+kubernetes_version           = "1.27"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "kubernetes_config_map" "sas_iac_buildinfo" {
   }
 
   data = {
-    git-hash = data.external.git_hash.result["git-hash"]
+    git-hash    = data.external.git_hash.result["git-hash"]
     timestamp   = chomp(timestamp())
     iac-tooling = var.iac_tooling
     terraform   = <<EOT
@@ -153,7 +153,7 @@ module "eks" {
   node_security_group_enable_recommended_rules = false
 
   # enabled by default in v19, setting to false to preserve original behavior.
-  create_kms_key = false
+  create_kms_key            = false
   cluster_encryption_config = []
 
   ################################################################################
@@ -164,7 +164,7 @@ module "eks" {
   iam_role_arn    = var.cluster_iam_role_arn
 
   iam_role_additional_policies = {
-    "additional": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+    "additional" : "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   }
 
   ## Use this to define any values that are common and applicable to all Node Groups

--- a/variables.tf
+++ b/variables.tf
@@ -149,7 +149,7 @@ variable "efs_throughput_rate" {
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version."
   type        = string
-  default     = "1.26"
+  default     = "1.27"
 }
 
 variable "tags" {


### PR DESCRIPTION
### Changes
- Updated default kubernetes_version in variables.tf to 1.27
- Updated the default kubernetes_version in the example files to 1.27.
- Updated the default kubectl version in the Dockerfile to 1.27.9 (currently the latest)

### Tests

|Scenario|Provider|kubernetes_version|kubectl version|order|cadence|notes|
|-|-|-|-|-|-|-|
|1|AWS|1.26 (v1.26.11-eks)|1.27.9|**|stable:2023.12|docker, deploy command|
|2|AWS|1.27 (v1.27.8-eks)|1.27.9|**|stable:2023.10|docker, deploy command|
|3|AWS|1.28 (v1.28.4-eks)|1.27.9|**|stable:2023.12| not yet supported |