### PR TITLE
feat: (IAC-1259) AWS - Security scan 2024.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following are also required:
 
 #### Terraform Requirements:
 
-- [Terraform](https://www.terraform.io/downloads.html) v1.6.3
+- [Terraform](https://www.terraform.io/downloads.html) v1.6.6
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.27.9
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.13.33

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ module "vpc" {
 # EKS Setup - https://github.com/terraform-aws-modules/terraform-aws-eks
 module "eks" {
   source                               = "terraform-aws-modules/eks/aws"
-  version                              = "19.19.1"
+  version                              = "~> 19.0"
   cluster_name                         = local.cluster_name
   cluster_version                      = var.kubernetes_version
   cluster_enabled_log_types            = [] # disable cluster control plan logging
@@ -228,7 +228,7 @@ module "kubeconfig" {
 # Database Setup - https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/6.2.0
 module "postgresql" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.2.0"
+  version = "~> 6.0"
 
   for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
 

--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "worker_autoscaling" {
 
 module "iam_assumable_role_with_oidc" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "5.30.2"
+  version = "~> 5.0"
 
   create_role                   = true
   role_name                     = "${var.prefix}-cluster-autoscaler"

--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -1,15 +1,6 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-terraform {
-  required_version = ">= 1.4.5"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "5.25.0"
-    }
-  }
-}
 
 # Permissions based off the IAM Policy recommended by kubernetes/autoscaler
 # https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.25.0/cluster-autoscaler/cloudprovider/aws/README.md

--- a/modules/aws_ebs_csi/main.tf
+++ b/modules/aws_ebs_csi/main.tf
@@ -158,7 +158,7 @@ EOT
 
 module "iam_assumable_role_with_oidc" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "5.30.2"
+  version = "~> 5.0"
 
   create_role                    = true
   role_name                      = "${var.prefix}-ebs-csi-role"

--- a/modules/aws_ebs_csi/main.tf
+++ b/modules/aws_ebs_csi/main.tf
@@ -1,15 +1,6 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-terraform {
-  required_version = ">= 1.4.5"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "5.25.0"
-    }
-  }
-}
 
 resource "aws_iam_policy" "ebs_csi" {
   name_prefix = "${var.prefix}-ebs-csi-policy"

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -1,19 +1,6 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-terraform {
-  required_version = ">= 1.4.5"
-  required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "2.23.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = "2.4.0"
-    }
-  }
-}
 
 locals {
   service_account_name        = "${var.prefix}-cluster-admin-sa"

--- a/versions.tf
+++ b/versions.tf
@@ -6,35 +6,35 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.25.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.5.1"
+      version = "~> 3.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.4.0"
+      version = "~> 2.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.2.1"
+      version = "~> 3.0"
     }
     external = {
       source  = "hashicorp/external"
-      version = "2.3.1"
+      version = "~> 2.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.23.0"
+      version = "~> 2.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.4"
+      version = "~> 4.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = "2.3.2"
+      version = "~> 2.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {
-  required_version = ">= 1.4.5"
+  required_version = ">= 1.6.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
### Changes

Updates 3rd party dependencies to resolve the security vulnerabilities. Users of the Dockerfile will automatically have these updated dependencies installed, and users who directly run this project on the host will need to update the dependencies themselves.

Update summary:

#### CLI

- terraform 1.6.3 -> 1.6.6
  - updates google.golang.org/grpc from v1.56.1 to v1.59 to remediate High CVE-2023-44487
  - updates golang.org/x/net from v0.8.0 to v0.19.0, remediating multiple high CVEs

#### Providers

- hashicorp/aws from 5.25.0 to 5.31.0
  - bug fixes, features and enhancements, 5.27.0 includes an update to the AWS SDK for Go v2, provider changes should be transparent to users
- hashicorp/cloudinit from 2.3.2 to 2.3.3
  - no functional changes, does include dependency updates to address upstream CVEs
- hashicorp/external from 2.3.1 to 2.3.2
  - bug fixes
- hashicorp/kubernetes from 2.23.0 to 2.25.1
  - docs, bug fixes and enhancements
- hashicorp/local from 2.4.0 to 2.4.1
  - This release introduces no functional changes. It does however include dependency updates which address upstream CVEs. [#273](https://github.com/hashicorp/terraform-provider-local/pull/273)
- hashicorp/null from 3.2.1 to 3.2.2
  - This release introduces no functional changes. It does however include dependency updates which address upstream CVEs. [#242](https://github.com/hashicorp/terraform-provider-null/issues/242)
- hashicorp/random from 3.5.1 to 3.6.0
  - one new feature
- hashicorp/time from 0.9.2 to 0.10.0
  - one bug fix

#### Modules

- update registry.terraform.io/terraform-aws-modules/eks/aws from 19.19.1 to 19.21.0 for eks...
  - 2 added features, no breaking changes
- update registry.terraform.io/terraform-aws-modules/rds/aws from 6.2.0 to 6.3.0 for postgresql ...
  - 1 feature added, no breaking changes
- update terraform-aws-modules/iam/aws/modules/iam-assumable-role-with-oidc from 5.30.2 to 5.33.0
  - bug fixes and new feature

### Tests

|Scenario|Provider|K8s version|Order|Cadence|
|-|-|-|-|-|
|1|AWS|1.27.8-eks | **** |fast:2020 |