### PR TITLE
chore: (IAC-1259) Bump container test expected versions for terraform

### DIFF
--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "terraform version"
     command: "terraform"
     args: ["--version"]
-    expectedOutput: ["Terraform v1.6.3"]
+    expectedOutput: ["Terraform v1.6.6"]
   - name: "aws-cli version"
     command: "sh"
     args:


### PR DESCRIPTION
### Changes
Terraform binary version update in PR #261 required version bump in container-structure-test.yaml file for github action executed for PRs targeting the main branch.
