### PR TITLE
fix: (IAC-922) Assign tags to resources missing them

### DIFF
--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -68,8 +68,10 @@ module "iam_assumable_role_with_oidc" {
   role_policy_arns              = [aws_iam_policy.worker_autoscaling.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler"]
 
-  tags = {
-    Role = "${var.prefix}-cluster-autoscaler"
-  }
-
+  tags = merge(
+    {
+      Role = "${var.prefix}-cluster-autoscaler"
+    },
+    var.tags
+  )
 }

--- a/modules/aws_ebs_csi/main.tf
+++ b/modules/aws_ebs_csi/main.tf
@@ -167,10 +167,12 @@ module "iam_assumable_role_with_oidc" {
   oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
   oidc_fully_qualified_subjects  = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
 
-  tags = {
-    Role = "${var.prefix}-ebs-csi-role"
-  }
-
+  tags = merge(
+    {
+      Role = "${var.prefix}-ebs-csi-role"
+    },
+    var.tags
+  )
 }
 
 resource "aws_iam_role_policy_attachment" "ebs_attachment" {

--- a/modules/aws_vm/main.tf
+++ b/modules/aws_vm/main.tf
@@ -105,7 +105,7 @@ resource "aws_eip" "eip" {
   count    = var.create_public_ip ? 1 : 0
   domain   = "vpc"
   instance = aws_instance.vm.id
-  tags     = merge({ Name : "${var.name}-eip" }, var.tags)
+  tags = merge(var.tags, tomap({ Name : "${var.name}-eip" }))
 }
 
 resource "aws_volume_attachment" "data-volume-attachment" {

--- a/modules/aws_vm/main.tf
+++ b/modules/aws_vm/main.tf
@@ -81,6 +81,7 @@ resource "aws_instance" "vm" {
     delete_on_termination = var.os_disk_delete_on_termination
     iops                  = var.os_disk_iops
     encrypted             = var.enable_ebs_encryption
+    tags                  = merge(var.tags, tomap({ Name : "${var.name}-root-vol" }))
   }
 
   tags = merge(var.tags, tomap({ Name : "${var.name}-vm" }))

--- a/modules/aws_vm/main.tf
+++ b/modules/aws_vm/main.tf
@@ -81,7 +81,12 @@ resource "aws_instance" "vm" {
     delete_on_termination = var.os_disk_delete_on_termination
     iops                  = var.os_disk_iops
     encrypted             = var.enable_ebs_encryption
-    tags                  = merge(var.tags, tomap({ Name : "${var.name}-root-vol" }))
+    tags                  = merge(
+                              {
+                                Name : "${var.name}-root-vol"
+                              },
+                              var.tags
+                            )
   }
 
   tags = merge(var.tags, tomap({ Name : "${var.name}-vm" }))
@@ -100,7 +105,7 @@ resource "aws_eip" "eip" {
   count    = var.create_public_ip ? 1 : 0
   domain   = "vpc"
   instance = aws_instance.vm.id
-  tags     = merge(var.tags, tomap({ Name : "${var.name}-eip" }))
+  tags     = merge({ Name : "${var.name}-eip" }, var.tags)
 }
 
 resource "aws_volume_attachment" "data-volume-attachment" {

--- a/modules/aws_vm/main.tf
+++ b/modules/aws_vm/main.tf
@@ -105,7 +105,7 @@ resource "aws_eip" "eip" {
   count    = var.create_public_ip ? 1 : 0
   domain   = "vpc"
   instance = aws_instance.vm.id
-  tags = merge(var.tags, tomap({ Name : "${var.name}-eip" }))
+  tags     = merge(var.tags, tomap({ Name : "${var.name}-eip" }))
 }
 
 resource "aws_volume_attachment" "data-volume-attachment" {


### PR DESCRIPTION
### Changes

Fix for resources that did not have tags set for them. The following resources will now have tags applied:

* cluster-autoscaler IAM Role
* ebs-csi IAM role
* Jump vm root volume
* NFS vm root volume

### Tests

| Scenario | Provider | K8s Version         | Order  | Cadence   | Notes                                                                            |
|----------|----------|---------------------|--------|-----------|----------------------------------------------------------------------------------|
| 1        | AWS      | v1.27.9-eks-5e0fdde | ****** | fast:2020 | tags applied to resources                                                        |
| 2        | AWS      | v1.27.9-eks-5e0fdde | N/A    | N/A       | 8.1.0 initial infra creation, apply again with PR code, resources had tags added |
