### PR TITLE
chore: (IAC-1330) Update container structure workflow to run acceptance test for PRs targeting staging branch

### DIFF
--- a/.github/workflows/container-structure-test.yml
+++ b/.github/workflows/container-structure-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging ]
 
 jobs:
   acceptance:


### PR DESCRIPTION
### Changes
Currently, the container structure test github action only runs on pushes and pull requests to the main branch. That is too late and can result in acceptance test failures when creating the staging->main PR when it's time to create a new release. It would be more helpful for that acceptance test to run earlier. Adding a trigger to run this same test for pull requests to staging branch also which will allow us to find any failures earlier in our workflow.

### Test

Screen capture of the checks run below indicate that the container acceptance tests ran for this PR when it was created and targeted to merge into staging which was the goal of this change.

![image](https://github.com/sassoftware/viya4-iac-aws/assets/6422249/ec84f39f-8c35-496b-8bf3-3fe5844a9ca4)
