### PR TITLE
feat: (IAC-1347) Updated external Postgres server version to 15

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -387,7 +387,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 <!--| Name | Description | Type | Default | Notes | -->
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
-| server_version | The version of the PostgreSQL server | string | "13" | Refer to the [SAS Viya platform Administration Guide](https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
+| server_version | The version of the PostgreSQL server | string | "15" | Refer to the [SAS Viya platform Administration Guide](https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | instance_type | The VM type for the PostgreSQL Server | string | "db.m5.xlarge" | |
 | storage_size | Max storage allowed for the PostgreSQL server in MB | number | 50 |  |
 | backup_retention_days | Backup retention days for the PostgreSQL server | number | 7 | Supported values are between 7 and 35 days. |
@@ -418,7 +418,7 @@ postgres_servers = {
     deletion_protection          = false
     administrator_login          = "cdsadmin"
     administrator_password       = "1tsAB3aut1fulDay"
-    server_version               = "13"
+    server_version               = "15"
     server_port                  = "5432"
     ssl_enforcement_enabled      = true
     parameters                   = [{ "apply_method": "immediate", "name": "foo" "value": "true" }, { "apply_method": "immediate", "name": "bar" "value": "false" }]

--- a/variables.tf
+++ b/variables.tf
@@ -532,7 +532,7 @@ variable "postgres_server_defaults" {
     deletion_protection     = false
     administrator_login     = "pgadmin"
     administrator_password  = "my$up3rS3cretPassw0rd"
-    server_version          = "13"
+    server_version          = "15"
     server_port             = "5432"
     ssl_enforcement_enabled = true
     parameters              = []


### PR DESCRIPTION
## Changes:
This PR updates the default Postgres Server version from 13 to 15, For more details of supported versions see [SAS documentation External PostgreSQL Requirements](https://go.documentation.sas.com/doc/en/sasadmincdc/v_048/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u).

## Tests:
Verified to make sure version 15 was used by default. See test details in internal ticket

| Scenario | Provider | Task          | Kubernetes version | order  | cadence        |
|----------|----------|-----------------------------|-------------|--------|-------|
| 1        | AWS | External Postgres with defaults  | 1.27  | ****** | fast:2020|