### PR TITLE
feat: (IAC-1376) Add Support for K8s 1.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AWS_CLI_VERSION=2.13.33
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.27.9
+ARG KUBECTL_VERSION=1.28.7
 
 WORKDIR /viya4-iac-aws
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.6.6
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.27.9
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.28.7
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.13.33
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -257,7 +257,7 @@ Custom policy:
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | create_static_kubeconfig | Allows the user to create a provider- or service account-based kubeconfig file | bool | true | A value of `false` defaults to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` creates a static kubeconfig that uses a service account and cluster role binding to provide credentials. |
-| kubernetes_version | The EKS cluster Kubernetes version | string | "1.27" | |
+| kubernetes_version | The EKS cluster Kubernetes version | string | "1.28" | |
 | create_jump_vm | Create bastion host (jump VM) | bool | true| |
 | create_jump_public_ip | Add public IP address to jump VM | bool | true | |
 | jump_vm_admin | OS admin user for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 1
 default_nodepool_vm_type     = "m5.large"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.27"
+kubernetes_version           = "1.28"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "m5.2xlarge"
 default_nodepool_custom_data = ""

--- a/variables.tf
+++ b/variables.tf
@@ -149,7 +149,7 @@ variable "efs_throughput_rate" {
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version."
   type        = string
-  default     = "1.27"
+  default     = "1.28"
 }
 
 variable "tags" {


### PR DESCRIPTION
### Changes

* Updated the default `kubernetes_version` in the example files to 1.28.
* Updated the default `kubectl` version in the Dockerfile to 1.28.7 (currently the latest)

### Tests

| Scenario | Provider | K8s Version          | kubectl | Order  | Cadence   | Notes                                      |
|----------|----------|----------------------|---------|--------|-----------|--------------------------------------------|
| 1        | AWS      | v1.29.1-eks-b9c9ed7  | 1.28.7  | * | fast:2020 | OOTB                                       |
| 2        | AWS      | v1.28.7-eks-b9c9ed7  | 1.28.7  | * | fast:2020 | OOTB                                       |
| 3        | AWS      | v1.27.11-eks-b9c9ed7 | 1.28.7  | * | fast:2020 | OOTB - overwrite kubectl version in the DO |
