### PR TITLE
fix: (IAC-1380) AWS Autoscaling Launch Template Tags Incorrect

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -102,7 +102,8 @@ locals {
       launch_template_name            = "${local.cluster_name}-default-lt"
       launch_template_use_name_prefix = true
       launch_template_tags            = { Name = "${local.cluster_name}-default" }
-      tags                            = var.autoscaling_enabled ? merge(local.tags, { key = "k8s.io/cluster-autoscaler/${local.cluster_name}", value = "owned", propagate_at_launch = true }, { key = "k8s.io/cluster-autoscaler/enabled", value = "true", propagate_at_launch = true }) : local.tags
+      tags                            = var.autoscaling_enabled ? merge(local.tags, { "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned", propagate_at_launch = true }, { "k8s.io/cluster-autoscaler/enabled" = "true", propagate_at_launch = true }) : local.tags
+
       # Node Pool IAM Configuration
       iam_role_use_name_prefix = false
       iam_role_name            = "${var.prefix}-default-eks-node-group"
@@ -151,7 +152,7 @@ locals {
       launch_template_name            = "${local.cluster_name}-${key}-lt"
       launch_template_use_name_prefix = true
       launch_template_tags            = { Name = "${local.cluster_name}-${key}" }
-      tags                            = var.autoscaling_enabled ? merge(local.tags, { key = "k8s.io/cluster-autoscaler/${local.cluster_name}", value = "owned", propagate_at_launch = true }, { key = "k8s.io/cluster-autoscaler/enabled", value = "true", propagate_at_launch = true }) : local.tags
+      tags                            = var.autoscaling_enabled ? merge(local.tags, { "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned", propagate_at_launch = true }, { "k8s.io/cluster-autoscaler/enabled" = "true", propagate_at_launch = true }) : local.tags
       # Node Pool IAM Configuration
       iam_role_use_name_prefix = false
       iam_role_name            = "${var.prefix}-${key}-eks-node-group"


### PR DESCRIPTION
# Changes
- Update the k8s.io/cluster-autoscaler key and tag values for the default_node_pool and the user_node_pool to align them with what is expected.
# Tests
- Verify that the EC2 node instances created by the Auto Scaling Group include the two updated k8s.io/cluster-autoscaler key and tag values made under this PR. Details are included in the testing assets file available in the internal ticket.

| Provider | K8S Version | TF input file | region | Notes |
|-|-|-|-|-|
| AWS | 1.28 | terraform-input-byongp3.tfvars | us-west-1 | Both updated k8s.io/cluster-autoscaler/* Tag key and value pairs are present after cluster create as desired. See assets zip file on internal ticket for command output details and Terraform input file content.