### PR TITLE
Fix autoscaling policy to correctly handle eks:DescribeNodegroup permission

### DIFF
--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -17,6 +17,9 @@ data "aws_iam_policy_document" "worker_autoscaling" {
       "autoscaling:DescribeTags",
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
 
     resources = ["*"]
@@ -29,25 +32,23 @@ data "aws_iam_policy_document" "worker_autoscaling" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-      "ec2:DescribeImages",
-      "ec2:GetInstanceTypesFromInstanceRequirements",
-      "eks:DescribeNodegroup"
+      "autoscaling:UpdateAutoScalingGroup"
     ]
 
     resources = ["*"]
 
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${var.cluster_name}"
-      values   = ["owned"]
-    }
+    # Remove the following conditions that are incorrect for eks:DescribeNodegroup
+    # condition {
+    #   test     = "StringEquals"
+    #   variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${var.cluster_name}"
+    #   values   = ["owned"]
+    # }
 
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
-      values   = ["true"]
-    }
+    # condition {
+    #   test     = "StringEquals"
+    #   variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+    #   values   = ["true"]
+    # }
   }
 }
 
@@ -75,3 +76,4 @@ module "iam_assumable_role_with_oidc" {
     var.tags
   )
 }
+


### PR DESCRIPTION
##Summary
This PR fixes the IAM policy for the Cluster Autoscaler to correctly handle the `eks:DescribeNodegroup` permission.

##Rationale
The Cluster Autoscaler encounters the following error, indicating an AccessDeniedException for "eks:DescribeNodegroup":

E0604 20:35:15.324713 1 aws_manager.go:308] Failed to get labels from EKS DescribeNodegroup API for nodegroup cas-202401... in cluster viya-... because AccessDeniedException: User: arn:aws:sts::7...
/viya-...-cluster-autoscaler/17... is not authorized to perform  eks:DescribeNodegroup on resource: arn:aws:eks:ca-central-1:7...:nodegroup/viya.../cas-202401...-dea0-52....

The condition in the existing policy applies to Auto Scaling Groups, but eks:DescribeNodegroup operates on EKS-managed node groups. IAM permissions might be checking for these tags on the node group resource, not just the underlying ASG. As a result, tags on ASGs might not propagate or apply in the way it is expected. 

