### PR TITLE
feat: (IAC-1472) AWS - Security scan 2024.06

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG TERRAFORM_VERSION=1.8.3
-ARG AWS_CLI_VERSION=2.15.46
+ARG TERRAFORM_VERSION=1.8.5
+ARG AWS_CLI_VERSION=2.16.5
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM amazon/aws-cli:$AWS_CLI_VERSION
-ARG KUBECTL_VERSION=1.28.7
+ARG KUBECTL_VERSION=1.28.11
 
 WORKDIR /viya4-iac-aws
 
@@ -17,7 +17,7 @@ RUN yum -y install git openssh jq which \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \
   && chmod g=u -R /etc/passwd /etc/group /viya4-iac-aws \
-  && git config --system --add safe.directory /viya4-iac-aws \
+  && git config --system --add safe.directory /viya4-iac-aws ||: \
   && terraform init
 
 ENV TF_VAR_iac_tooling=docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yum -y install git openssh jq which \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \
   && chmod g=u -R /etc/passwd /etc/group /viya4-iac-aws \
-  && git config --system --add safe.directory /viya4-iac-aws ||: \
+  && git config --system --add safe.directory /viya4-iac-aws \
   && terraform init
 
 ENV TF_VAR_iac_tooling=docker

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -17,14 +17,14 @@ commandTests:
   - name: "terraform version"
     command: "terraform"
     args: ["--version"]
-    expectedOutput: ["Terraform v1.8.3"]
+    expectedOutput: ["Terraform v1.8.5"]
   - name: "aws-cli version"
     command: "sh"
     args:
       - -c
       - |
         aws --version
-    expectedOutput: ["aws-cli/2.15.46"]
+    expectedOutput: ["aws-cli/2.16.5"]
 
 metadataTest:
   workdir: "/viya4-iac-aws"


### PR DESCRIPTION
Update Terraform, AWS cli and kubectl versions to remediate the High security vulnerabilities reported by the most recent Aqua Scan, see full results in the internal ticket.

Final scan result has: 0 Critical, 0 High security vulnerabilities.