### PR TITLE
fix: (PSKD-494) AWS - private endpoint type for S3 should be of type Interface

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -636,7 +636,7 @@ variable "vpc_private_endpoints" { # tflint-ignore: terraform_unused_declaration
     "ec2"                  = "Interface",
     "ecr.api"              = "Interface",
     "ecr.dkr"              = "Interface",
-    "s3"                   = "Gateway",
+    "s3"                   = "Interface",
     "logs"                 = "Interface",
     "sts"                  = "Interface",
     "elasticloadbalancing" = "Interface",


### PR DESCRIPTION
## Summary: 
Revise a previously made update to the type for the s3 private endpoint used in private EKS clusters.
Issue Description: Be default, the viya4-iac-aws project should create the s3 private endpoint with a type of "interface". Currently, viya4-iac-aws creates a s3 private endpoint with a type of "gateway" for use with private EKS clusters. [IAC-759](https://rndjira.sas.com/browse/IAC-759) incorrectly advised that the s3 private endpoint should be changed to a type of "gateway". That could work, but additional more complex routing configuration not already present in the project would be required in order for the s3 private endpoint to work with a type "gateway".

Additional testing since then has shown that the existing "interface" type for the s3 private endpoint is sufficient and works as intended, so this work item will revert the ill-advised change originally requested by [IAC-759](https://rndjira.sas.com/browse/IAC-759).

## Tests
Use IAC AWS (Run a terraform apply command, BYON = 0) to successfully create an EKS K8S cluster with the configuration variable `cluster_api_mode` set to the following values:

- public
- private