### PR TITLE
Revert "fix: (PSKD-678) viya4-aws-iac creates an incomplete IAM policy for the autoscaler Service Account"

### DIFF
--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -3,7 +3,7 @@
 
 
 # Permissions based off the IAM Policy recommended by kubernetes/autoscaler
-# https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.36.0/cluster-autoscaler/cloudprovider/aws/README.md
+# https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.25.0/cluster-autoscaler/cloudprovider/aws/README.md
 data "aws_iam_policy_document" "worker_autoscaling" {
   statement {
     sid    = "eksWorkerAutoscalingAll"
@@ -17,9 +17,6 @@ data "aws_iam_policy_document" "worker_autoscaling" {
       "autoscaling:DescribeTags",
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
-      "ec2:DescribeImages",
-      "ec2:GetInstanceTypesFromInstanceRequirements",
-      "eks:DescribeNodegroup"
     ]
 
     resources = ["*"]
@@ -32,7 +29,10 @@ data "aws_iam_policy_document" "worker_autoscaling" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup"
+      "autoscaling:UpdateAutoScalingGroup",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Reverts sassoftware/viya4-iac-aws#300