### PR TITLE
fix: (PSKD-678) viya4-aws-iac creates an incomplete IAM policy for the autoscaler Service Account redo

### DIFF
--- a/modules/aws_autoscaling/main.tf
+++ b/modules/aws_autoscaling/main.tf
@@ -3,7 +3,7 @@
 
 
 # Permissions based off the IAM Policy recommended by kubernetes/autoscaler
-# https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.25.0/cluster-autoscaler/cloudprovider/aws/README.md
+# https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.36.0/cluster-autoscaler/cloudprovider/aws/README.md
 data "aws_iam_policy_document" "worker_autoscaling" {
   statement {
     sid    = "eksWorkerAutoscalingAll"
@@ -17,6 +17,9 @@ data "aws_iam_policy_document" "worker_autoscaling" {
       "autoscaling:DescribeTags",
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
 
     resources = ["*"]
@@ -29,10 +32,8 @@ data "aws_iam_policy_document" "worker_autoscaling" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-      "ec2:DescribeImages",
-      "ec2:GetInstanceTypesFromInstanceRequirements",
-      "eks:DescribeNodegroup"
+      "autoscaling:UpdateAutoScalingGroup"
+      
     ]
 
     resources = ["*"]


### PR DESCRIPTION
We've updated the IAM cluster-autoscaler policy to address an unwanted error message

kubectl -n kube-system logs -l 'app.kubernetes.io/instance=cluster-autoscaler' --tail=-1 | grep '^E'

 
E0604 20:35:15.324713 1 aws_manager.go:308] Failed to get labels from EKS DescribeNodegroup API for nodegroup cas-202401... in cluster viya-... because AccessDeniedException: User: arn:aws:sts::7...
/viya-...-cluster-autoscaler/17... is not authorized to perform eks:DescribeNodegroup on resource: arn:aws:eks:ca-central-1:7...:nodegroup/viya.../cas-202401...-dea0-52....