### PR TITLE
(PSKD-434) AWS no longer has a default storage class with K8s 1.30

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -226,7 +226,7 @@ module "kubeconfig" {
 }
 
 # Normally, the use of local-exec below is avoided. It is used here to patch the gp2 storage class as the default storage class for EKS 1.30 and later clusters.
-# In the near future, adopting a newer version of the aws-ebs-csi-driver will create a new gp3-based storage class which will become the default storage class.
+# PSKD-667 will track the move to a newer version of the aws-ebs-csi-driver creating a gp3 storage class which will then become the default storage class.
 resource "terraform_data" "run_command" {
   count = var.kubernetes_version >= "1.30" ? 1 : 0
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,8 @@ module "kubeconfig" {
   depends_on = [module.eks.cluster_name] # The name/id of the EKS cluster. Will block on cluster creation until the cluster is really ready.
 }
 
-# Restore the gp2 storage class as the default storage class for EKS 1.30 and later clusters
+# Normally, the use of local-exec below is avoided. It is used here to patch the gp2 storage class as the default storage class for EKS 1.30 and later clusters.
+# In the near future, adopting a newer version of the aws-ebs-csi-driver will create a new gp3-based storage class which will become the default storage class.
 resource "terraform_data" "run_command" {
   count = var.kubernetes_version >= "1.30" ? 1 : 0
   provisioner "local-exec" {


### PR DESCRIPTION
### Changes required:
From https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html
> Starting with 1.30, Amazon EKS no longer includes the default annotation on the gp2 StorageClass resource applied to newly created clusters. This has no impact if you are referencing this storage class by name. You must take action if you were relying on having a default StorageClass in the cluster.

The changes made here are helping to mitigate issues arising from the last sentence above.

### Testing:
Internal testing of the proposed changes have been positive.