### PR TITLE
fix: permissions set in dockerfile (PSKD-903)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN yum -y install git openssh jq which \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-aws/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \
-  && chmod g=u -R /etc/passwd /etc/group /viya4-iac-aws \
   && git config --system --add safe.directory /viya4-iac-aws \
-  && terraform init
+  && terraform init \
+  && chmod g=u -R /etc/passwd /etc/group /viya4-iac-aws
 
 ENV TF_VAR_iac_tooling=docker
 ENTRYPOINT ["/viya4-iac-aws/docker-entrypoint.sh"]

--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -8,7 +8,7 @@
 # For more information on TFlint Ruleset for AWS, see https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/docs/rules/README.md
 
 config {
-  module = false
+  call_module_type = "none"
 }
 
 plugin "aws" {


### PR DESCRIPTION
## Changes:
"chmod" command in Dockerfile moved after the "terraform init" command to allow for overriding the default local backend.