### PR TITLE
feat: allow gp3 disk type in default_nodepool_os_disk_type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -177,8 +177,8 @@ variable "default_nodepool_os_disk_type" {
   default     = "gp2"
 
   validation {
-    condition     = contains(["gp2", "io1"], lower(var.default_nodepool_os_disk_type))
-    error_message = "ERROR: Supported values for `default_nodepool_os_disk_type` are gp2, io1."
+    condition     = contains(["gp3", "gp2", "io1"], lower(var.default_nodepool_os_disk_type))
+    error_message = "ERROR: Supported values for `default_nodepool_os_disk_type` are gp3, gp2, or io1."
   }
 }
 


### PR DESCRIPTION
This PR simply adds gp3 to the validation condition in variables.tf, making gp3 a valid option for `default_nodepool_os_disk_type`. The default of gp2 is preserved.