### PR TITLE
chore: Update AWS instance types to align with WW Sizing recommendations (PSKD-650)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -390,8 +390,8 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | server_version | The version of the PostgreSQL server | string | "15" | Refer to the [SAS Viya platform Administration Guide](https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
-| instance_type | The VM type for the PostgreSQL Server | string | "db.m5.xlarge" | |
-| storage_size | Max storage allowed for the PostgreSQL server in MB | number | 50 |  |
+| instance_type | The VM type for the PostgreSQL Server | string | "db.m6idn.xlarge" | |
+| storage_size | Max storage allowed for the PostgreSQL server in GB | number | 128 |  |
 | backup_retention_days | Backup retention days for the PostgreSQL server | number | 7 | Supported values are between 7 and 35 days. |
 | storage_encrypted | Encrypt PostgreSQL data at rest | bool | false| |
 | administrator_login | The Administrator Login for the PostgreSQL Server | string | "pgadmin" | The admin login name can not be 'admin', must start with a letter, and must be between 1-16 characters in length, and can only contain underscores, letters, and numbers. Changing this forces a new resource to be created |
@@ -412,8 +412,8 @@ postgres_servers = {
     administrator_password       = "D0ntL00kTh1sWay"
   },
   cds-postgres = {
-    instance_type                = "db.m5.xlarge"
-    storage_size                 = 50
+    instance_type                = "db.m6idn.xlarge"
+    storage_size                 = 128
     storage_encrypted            = false
     backup_retention_days        = 7
     multi_az                     = false

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -39,7 +39,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -49,7 +49,7 @@ storage_type         = "standard"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "m5.2xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -66,7 +66,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -84,7 +84,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -101,7 +101,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -29,7 +29,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -39,7 +39,7 @@ storage_type         = "standard"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "m5.2xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -56,7 +56,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -74,7 +74,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   connect = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -92,7 +92,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -109,7 +109,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -29,7 +29,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -39,7 +39,7 @@ storage_type         = "standard"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "i3.8xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -56,7 +56,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -74,7 +74,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -91,7 +91,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -29,7 +29,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -39,7 +39,7 @@ storage_type         = "standard"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "m5.2xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -73,7 +73,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -91,7 +91,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -108,7 +108,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -29,7 +29,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -39,7 +39,7 @@ storage_type         = "ha"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "i3.8xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -56,7 +56,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -74,7 +74,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -91,7 +91,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -29,7 +29,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 1
-default_nodepool_vm_type     = "m5.large"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -40,7 +40,7 @@ storage_type         = "standard"
 cluster_node_pool_mode = "minimal"
 node_pools = {
   cas = {
-    "vm_type"      = "r5.xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -57,7 +57,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   generic = {
-    "vm_type"      = "m5.2xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -85,4 +85,4 @@ jump_vm_type   = "t3.medium"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_type          = "m5.xlarge"
+nfs_vm_type          = "m6in.xlarge"

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -29,7 +29,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -39,7 +39,7 @@ storage_type         = "standard"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "m5.2xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -56,7 +56,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -74,7 +74,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -91,7 +91,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -108,7 +108,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   singlestore = {
-    "vm_type"      = "r4.4xlarge"
+    "vm_type"      = "r6idn.4xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -29,7 +29,7 @@ postgres_servers = {
 ## Cluster config
 kubernetes_version           = "1.30"
 default_nodepool_node_count  = 2
-default_nodepool_vm_type     = "m5.2xlarge"
+default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
 
 ## General
@@ -39,7 +39,7 @@ storage_type         = "standard"
 ## Cluster Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "m5.2xlarge"
+    "vm_type"      = "r6idn.2xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -56,7 +56,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   compute = {
-    "vm_type"      = "m5.8xlarge"
+    "vm_type"      = "m6idn.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -74,7 +74,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateless = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
@@ -91,7 +91,7 @@ node_pools = {
     "metadata_http_put_response_hop_limit" = 1
   },
   stateful = {
-    "vm_type"      = "m5.4xlarge"
+    "vm_type"      = "m6in.xlarge"
     "cpu_type"     = "AL2_x86_64"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200

--- a/modules/aws_vm/variables.tf
+++ b/modules/aws_vm/variables.tf
@@ -15,7 +15,7 @@ variable "tags" {
 variable "vm_type" {
   description = "EC2 instance type"
   type        = string
-  default     = "m5.4xlarge"
+  default     = "m6in.xlarge"
 }
 
 variable "cloud_init" {

--- a/variables.tf
+++ b/variables.tf
@@ -168,7 +168,7 @@ variable "create_default_nodepool" { # tflint-ignore: terraform_unused_declarati
 variable "default_nodepool_vm_type" {
   description = "Type of the default node pool VMs."
   type        = string
-  default     = "m5.2xlarge"
+  default     = "r6in.2xlarge"
 }
 
 variable "default_nodepool_os_disk_type" {
@@ -271,7 +271,7 @@ variable "node_pools" {
 
   default = {
     cas = {
-      "vm_type"      = "m5.2xlarge"
+      "vm_type"      = "r6idn.2xlarge"
       "cpu_type"     = "AL2_x86_64"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
@@ -288,7 +288,7 @@ variable "node_pools" {
       "metadata_http_put_response_hop_limit" = 1
     },
     compute = {
-      "vm_type"      = "m5.8xlarge"
+      "vm_type"      = "m6idn.xlarge"
       "cpu_type"     = "AL2_x86_64"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
@@ -306,7 +306,7 @@ variable "node_pools" {
       "metadata_http_put_response_hop_limit" = 1
     },
     stateless = {
-      "vm_type"      = "m5.4xlarge"
+      "vm_type"      = "m6in.xlarge"
       "cpu_type"     = "AL2_x86_64"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
@@ -323,7 +323,7 @@ variable "node_pools" {
       "metadata_http_put_response_hop_limit" = 1
     },
     stateful = {
-      "vm_type"      = "m5.4xlarge"
+      "vm_type"      = "m6in.xlarge"
       "cpu_type"     = "AL2_x86_64"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
@@ -448,7 +448,7 @@ variable "jump_vm_admin" {
 variable "jump_vm_type" {
   description = "Jump VM type."
   type        = string
-  default     = "m5.4xlarge"
+  default     = "m6in.xlarge"
 }
 
 variable "jump_rwx_filestore_path" {
@@ -490,7 +490,7 @@ variable "nfs_vm_admin" {
 variable "nfs_vm_type" {
   description = "NFS VM type."
   type        = string
-  default     = "m5.4xlarge"
+  default     = "m6in.xlarge"
 }
 
 variable "os_disk_size" {
@@ -524,8 +524,8 @@ variable "postgres_server_defaults" {
   description = "Map of PostgresSQL server default objects."
   type        = any
   default = {
-    instance_type           = "db.m5.xlarge"
-    storage_size            = 50
+    instance_type           = "db.m6idn.xlarge"
+    storage_size            = 128
     storage_encrypted       = false
     backup_retention_days   = 7
     multi_az                = false


### PR DESCRIPTION
### Changes
- Update all example/sample*.tfvars files instance types to comply with SAS Worldwide Sizing recommendations
- Update project defaults for vms and eks node instance types to match SAS Worldwide Sizing recommendations
- Update the default external Postgres disk size to 128 GB per SAS Worldwide Sizing recommendation
- Fix Postgres `storage_size` configuration variable units reference to indicate GB 

### Tests
- Used the updated sample-input.tfvars file to successfully provision a new EKS cluster with IaC AWS.
- Verified that the resulting VM and EKS node EC2 instance types used were those specified as a project default or present in the sample-input.tfvars file.
- Verified that the initial external Postgres disk size is 128 GB instead of 50 GB.