### PR TITLE
docs: Add additional security_group_ids to sample-input-byo.tfvars (PSKD-1292)

### DIFF
--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -17,6 +17,8 @@ subnet_ids = {               # only needed if using pre-existing subnets
 }
 nat_id            = "<existing-NAT-gateway-id>"
 security_group_id = "<existing-security-group-id>" # only needed if using pre-existing Security Group
+cluster_security_group_id = "<existing-cluster-security-group-id>" # only needed if using pre-existing Cluster Security Group
+workers_security_group_id  = "<existing-workers-security-group-id>"  # only needed if using pre-existing Security Group for Node Group VMs
 
 # !NOTE! - Without specifying your CIDR block access rules, ingress traffic
 #          to your cluster will be blocked by default.

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -15,10 +15,10 @@ subnet_ids = {               # only needed if using pre-existing subnets
   "private" : ["existing-private-subnet-id1", "existing-private-subnet-id2"],
   "database" : ["existing-database-subnet-id1", "existing-database-subnet-id2"] # only when 'create_postgres=true'
 }
-nat_id            = "<existing-NAT-gateway-id>"
-security_group_id = "<existing-security-group-id>" # only needed if using pre-existing Security Group
+nat_id                    = "<existing-NAT-gateway-id>"
+security_group_id         = "<existing-security-group-id>" # only needed if using pre-existing Security Group
 cluster_security_group_id = "<existing-cluster-security-group-id>" # only needed if using pre-existing Cluster Security Group
-workers_security_group_id  = "<existing-workers-security-group-id>"  # only needed if using pre-existing Security Group for Node Group VMs
+workers_security_group_id = "<existing-workers-security-group-id>" # only needed if using pre-existing Security Group for Node Group VMs
 
 # !NOTE! - Without specifying your CIDR block access rules, ingress traffic
 #          to your cluster will be blocked by default.

--- a/test/default_unit_test.go
+++ b/test/default_unit_test.go
@@ -41,7 +41,7 @@ func TestPlanDefaultDefaultNodepool(t *testing.T) {
 			attributeJsonPath: "{$.block_device_mappings[0].ebs[0].volume_type}",
 		},
 		"defaultNodepoolVmType": {
-			expected:          "[\"m5.2xlarge\"]",
+			expected:          "[\"r6in.2xlarge\"]",
 			resourceMapName:   "module.eks.module.eks_managed_node_group[\"default\"].aws_eks_node_group.this[0]",
 			attributeJsonPath: "{$.instance_types}",
 		},


### PR DESCRIPTION
### Changes
- Add the `cluster_security_group_id` and `workers_security_group_id` configuration variables and comments to the sample-input-byo.tfvars file. The resulting three security group ids complete the set of pre-existing security group ids that can be configured when using a bring your own network (BYON) scenario with IaC AWS.
- Update the expected defaultNodepoolVmType to fix the default value test that began failing with changes implemented in PR #330 