### PR TITLE
docs: Correct parameter value syntax for external postgres servers (PSKD-1439)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -423,7 +423,7 @@ postgres_servers = {
     server_version               = "15"
     server_port                  = "5432"
     ssl_enforcement_enabled      = true
-    parameters                   = [{ "apply_method": "immediate", "name": "foo" "value": "true" }, { "apply_method": "immediate", "name": "bar" "value": "false" }]
+    parameters                   = [{ "apply_method": "pending-reboot", "name": "shared_preload_libraries", "value": "PGAUDIT,PG_CRON,PG_STAT_STATEMENTS" }, { "apply_method": "pending-reboot", "name": "bar", "value": "false" }]
     options                      = []
   }
 }


### PR DESCRIPTION
### Changes
- Add missing comma to the external postgres servers parameters value list and include a working example value that can be used to set the `shared_preload_libraries` parameter correctly.

### Tests
Using the first parameters value list in the updated parameters example, I was able to confirm the set of `shared_preload_libraries` for the Postgres instance was set properly by examining the RDS postgres instance parameter_group in the AWS Portal. If I remove the required comma between the name/value pair, I was able to duplicate the same error message documented in the description for the internal ticket.


The shared_preload_libraries value captured from the AWS Portal for the created external Postgres instance indicates that the expected value has been set correctly.
```code
Name, Value, Apply type, Data type, Value type, Source
shared_preload_libraries, PGAUDIT,PG_CRON,PG_STAT_STATEMENTS, Static, list, Modifiable, Modified
```