### PR TITLE
ci: (PSKD-1515) add release workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,58 @@
+name-template: 'v$RESOLVED_VERSION - <RELEASE_DATE>'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '⚠️ BREAKING CHANGES'
+    labels:
+      - 'breaking change'
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+  - title: '⏱️ Performance'
+    labels:
+      - 'performance'
+  - title: '🤖 Tests'
+    labels:
+      - 'test'
+  - title: '🔧 Maintenance'
+    labels: 
+      - 'build'
+      - 'chore'
+      - 'CI/CD'
+      - 'refactor'
+      - 'revert'
+      - 'style'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'breaking change'
+  minor:
+    labels:
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'CI/CD'
+      - 'documentation'
+      - 'test'
+      - 'performance'
+      - 'refactor'
+      - 'chore'
+      - 'revert'
+      - 'style'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,7 +21,7 @@ categories:
     labels:
       - 'test'
   - title: '🔧 Maintenance'
-    labels: 
+    labels:
       - 'build'
       - 'chore'
       - 'CI/CD'

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,19 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
+      - staging
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+    # https://github.com/marketplace/actions/conventional-commit-in-pull-requests
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/pr-conventional-commits@1.4.0
+        with:
+          task_types: '["fix", "feat", "build", "chore", "ci", "docs", "style", "refactor", "perf", "test"]'
+          custom_labels: '{"feat": "enhancement", "fix": "bug", "docs": "documentation", "ci": "CI/CD", "perf": "performance"}'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semvar.yml
+++ b/.github/workflows/semvar.yml
@@ -1,0 +1,20 @@
+name: Update Semver
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+jobs:
+  update-semver:
+    # Update the tags based on semantic versioning.
+    # Also update the latest tag.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haya14busa/action-update-semver@v1
+      - name: Create latest git tag
+        run: |
+          git tag latest
+      - name: Push latest git tag
+        run: git push -f origin latest


### PR DESCRIPTION
Adding three new workflows to the project to help with organization and releases:

**PR Conventional Commit Validation** 
This workflow will require all PRs to have a valid conventional commit prefix. It assigns a label based on that prefix.

**Release Drafter**
This workflow will draft up the release notes based on the PRs that have been merged since the last release. It uses the PR labels to categorize the PRs.

**Update Semver**
This workflow will update the previous semantic versioned tags. For example, if we release `v1.2.3`, it will update `v1.2`, `v1`, and `latest`.