### PR TITLE
fix: restore ssh ingress rule for vms

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -52,7 +52,7 @@ resource "aws_vpc_security_group_ingress_rule" "sg" {
 
 resource "aws_vpc_security_group_ingress_rule" "vms" {
 
-  for_each = toset(local.vm_public_access_cidrs)
+  for_each = var.security_group_id == null && ((var.create_jump_public_ip && var.create_jump_vm) || (var.create_nfs_public_ip && var.storage_type == "standard")) ? toset(local.vm_public_access_cidrs) : toset([])
 
   security_group_id = local.security_group_id
 

--- a/security.tf
+++ b/security.tf
@@ -52,7 +52,7 @@ resource "aws_vpc_security_group_ingress_rule" "sg" {
 
 resource "aws_vpc_security_group_ingress_rule" "vms" {
 
-  for_each = var.security_group_id == null && ((var.create_jump_public_ip && var.create_jump_vm)) ? toset(local.vm_public_access_cidrs) : toset([])
+  for_each = toset(local.vm_public_access_cidrs)
 
   security_group_id = local.security_group_id
 

--- a/test/default_unit_test.go
+++ b/test/default_unit_test.go
@@ -83,3 +83,39 @@ func TestPlanDefaultEks(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanDefaultSecurityGroup(t *testing.T) {
+	variables := getDefaultPlanVars(t)
+	defaultTests := map[string]testCase{
+		"securityGroupCIDR": {
+			expected:          "123.45.67.89/32",
+			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			attributeJsonPath: "{$.cidr_ipv4}",
+		},
+		"securityGroupSSHIngressFromPort": {
+			expected:          "22",
+			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			attributeJsonPath: "{$.from_port}",
+		},
+		"securityGroupSSHIngressToPort": {
+			expected:          "22",
+			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			attributeJsonPath: "{$.to_port}",
+		},
+		"securityGroupIpProtocol": {
+			expected:          "tcp",
+			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			attributeJsonPath: "{$.ip_protocol}",
+		},
+	}
+
+	plan, err := initPlanWithVariables(t, variables)
+	require.NotNil(t, plan)
+	require.NoError(t, err)
+
+	for name, tc := range defaultTests {
+		t.Run(name, func(t *testing.T) {
+			runTest(t, tc, plan)
+		})
+	}
+}

--- a/test/default_unit_test.go
+++ b/test/default_unit_test.go
@@ -86,25 +86,26 @@ func TestPlanDefaultEks(t *testing.T) {
 
 func TestPlanDefaultSecurityGroup(t *testing.T) {
 	variables := getDefaultPlanVars(t)
+	default_cidr := variables["default_public_access_cidrs"].([]string)[0]
 	defaultTests := map[string]testCase{
 		"securityGroupCIDR": {
-			expected:          "123.45.67.89/32",
-			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			expected:          default_cidr,
+			resourceMapName:   fmt.Sprintf("aws_vpc_security_group_ingress_rule.vms[\"%s\"]", default_cidr),
 			attributeJsonPath: "{$.cidr_ipv4}",
 		},
 		"securityGroupSSHIngressFromPort": {
 			expected:          "22",
-			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			resourceMapName:   fmt.Sprintf("aws_vpc_security_group_ingress_rule.vms[\"%s\"]", default_cidr),
 			attributeJsonPath: "{$.from_port}",
 		},
 		"securityGroupSSHIngressToPort": {
 			expected:          "22",
-			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			resourceMapName:   fmt.Sprintf("aws_vpc_security_group_ingress_rule.vms[\"%s\"]", default_cidr),
 			attributeJsonPath: "{$.to_port}",
 		},
 		"securityGroupIpProtocol": {
 			expected:          "tcp",
-			resourceMapName:   "aws_vpc_security_group_ingress_rule.vms[\"123.45.67.89/32\"]",
+			resourceMapName:   fmt.Sprintf("aws_vpc_security_group_ingress_rule.vms[\"%s\"]", default_cidr),
 			attributeJsonPath: "{$.ip_protocol}",
 		},
 	}


### PR DESCRIPTION
Update the security group so that it adds the SSH ingress rules for the VMs. This is fixing a regression from the `8.7.0` release.

I've verified that the Jump VM and NFS VM have a SSH ingress rule for each IP in my default_public_access_cidrs. 