### PR TITLE
chore: update workflows to point to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "main"
     open-pull-requests-limit: 2
 
   # Docker dependencies
@@ -18,7 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "main"
     open-pull-requests-limit: 2
 
   # GitHub Actions
@@ -26,5 +26,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "main"
     open-pull-requests-limit: 2

--- a/.github/workflows/container-structure-test.yml
+++ b/.github/workflows/container-structure-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, staging ]
+    branches: [ main]
 
 jobs:
   acceptance:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches:
       - main
-      - staging
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
Modify workflows previously targeting 'staging' to now target the 'main' branch.