### PR TITLE
feat: add AWS 1.33 support (PSCLOUD-73)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
 FROM almalinux:minimal AS amin
 WORKDIR /app
 USER root
-ARG KUBECTL_VERSION=1.31.7
-ARG KUBECTL_CHECKSUM=80a3c83f00241cd402bc8688464e5e3eedd52a461ee41d882f19cf04ad6d0379
+ARG KUBECTL_VERSION=1.32.6
+ARG KUBECTL_CHECKSUM=0e31ebf882578b50e50fe6c43e3a0e3db61f6a41c9cded46485bc74d03d576eb
 RUN /usr/bin/bash -eux \
   && curl -fSLO https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl \

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.10.5
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.31.7
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.32.6
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.24.16
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -297,7 +297,7 @@ Additional node pools can be created separately from the default node pool. This
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | vm_type | Type of the node pool VMs | string | | https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html |
-| cpu_type | Processor type CPU/GPU | string | AL2023_x86_64_STANDARD| [AMI type](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) – Choose Amazon Linux 2 (AL2023_x86_64_STANDARD) for Linux non-GPU instances, Amazon Linux 2 GPU Enabled (AL2023_x86_64_STANDARD_GPU) for Linux GPU instances|
+| cpu_type | Processor type CPU/GPU | string | AL2023_x86_64_STANDARD| [AMI type](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) – Choose Amazon Linux 2 (AL2023_x86_64_STANDARD) for Linux non-GPU instances, Amazon Linux 2 GPU Enabled (AL2023_x86_64_NVIDIA) for Linux GPU instances|
 | os_disk_type | Disk type for node pool VMs | string | | `gp2` or `io1` |
 | os_disk_size | Disk size for node pool VMs in GB | number | | |
 | os_disk_iops | Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html) | number | | For `io1`, you MUST set the value to your desired IOPS value. Reference [Amazon EBS volume types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html) for details on values based on the `os_disk_type` selected.|

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -297,7 +297,7 @@ Additional node pools can be created separately from the default node pool. This
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | vm_type | Type of the node pool VMs | string | | https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html |
-| cpu_type | Processor type CPU/GPU | string | AL2023_x86_64_STANDARD| [AMI type](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) – Choose Amazon Linux 2 (AL2023_x86_64_STANDARD) for Linux non-GPU instances, Amazon Linux 2 GPU Enabled (AL2023_x86_64_NVIDIA) for Linux GPU instances|
+| cpu_type | Processor type CPU/GPU | string | AL2023_x86_64_STANDARD| [AMI type](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) – Choose Amazon Linux 2023 (AL2023_x86_64_STANDARD) for Linux non-GPU instances, Amazon Linux 2023 GPU Enabled (AL2023_x86_64_NVIDIA) for Linux GPU instances|
 | os_disk_type | Disk type for node pool VMs | string | | `gp2` or `io1` |
 | os_disk_size | Disk size for node pool VMs in GB | number | | |
 | os_disk_iops | Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html) | number | | For `io1`, you MUST set the value to your desired IOPS value. Reference [Amazon EBS volume types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html) for details on values based on the `os_disk_type` selected.|

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -297,7 +297,7 @@ Additional node pools can be created separately from the default node pool. This
 | <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:50px">Type</div> | <div style="width:75px">Default</div> | <div style="width:150px">Notes</div> |
 | :--- | :--- | :--- | :--- | :--- |
 | vm_type | Type of the node pool VMs | string | | https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html |
-| cpu_type | Processor type CPU/GPU | string | AL2_x86_64| [AMI type](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) – Choose Amazon Linux 2 (AL2_x86_64) for Linux non-GPU instances, Amazon Linux 2 GPU Enabled (AL2_x86_64_GPU) for Linux GPU instances|
+| cpu_type | Processor type CPU/GPU | string | AL2023_x86_64_STANDARD| [AMI type](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) – Choose Amazon Linux 2 (AL2023_x86_64_STANDARD) for Linux non-GPU instances, Amazon Linux 2 GPU Enabled (AL2023_x86_64_STANDARD_GPU) for Linux GPU instances|
 | os_disk_type | Disk type for node pool VMs | string | | `gp2` or `io1` |
 | os_disk_size | Disk size for node pool VMs in GB | number | | |
 | os_disk_iops | Amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html) | number | | For `io1`, you MUST set the value to your desired IOPS value. Reference [Amazon EBS volume types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html) for details on values based on the `os_disk_type` selected.|

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -39,7 +39,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -52,7 +52,7 @@ storage_type         = "standard"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -69,7 +69,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -87,7 +87,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -104,7 +104,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -40,7 +40,7 @@ storage_type         = "standard"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -57,7 +57,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -75,7 +75,7 @@ node_pools = {
   },
   connect = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -93,7 +93,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -110,7 +110,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -40,7 +40,7 @@ storage_type         = "standard"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -57,7 +57,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -75,7 +75,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -92,7 +92,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -40,7 +40,7 @@ storage_type         = "standard"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -57,7 +57,7 @@ node_pools = {
   },
   gpu_cas = {
     "vm_type"      = "p2.8xlarge"
-    "cpu_type"     = "AL2_x86_64_GPU"
+    "cpu_type"     = "AL2023_x86_64_NVIDIA"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -74,7 +74,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -92,7 +92,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -109,7 +109,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -40,7 +40,7 @@ storage_type         = "ha"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -57,7 +57,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -75,7 +75,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -92,7 +92,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 1
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -41,7 +41,7 @@ cluster_node_pool_mode = "minimal"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -58,7 +58,7 @@ node_pools = {
   },
   generic = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -40,7 +40,7 @@ storage_type         = "standard"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -57,7 +57,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -75,7 +75,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -92,7 +92,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -109,7 +109,7 @@ node_pools = {
   },
   singlestore = {
     "vm_type"      = "r6idn.4xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.31"
+kubernetes_version           = "1.32"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""
@@ -40,7 +40,7 @@ storage_type         = "standard"
 node_pools = {
   cas = {
     "vm_type"      = "r6idn.2xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -57,7 +57,7 @@ node_pools = {
   },
   compute = {
     "vm_type"      = "m6idn.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -75,7 +75,7 @@ node_pools = {
   },
   stateless = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0
@@ -92,7 +92,7 @@ node_pools = {
   },
   stateful = {
     "vm_type"      = "m6in.xlarge"
-    "cpu_type"     = "AL2_x86_64"
+    "cpu_type"     = "AL2023_x86_64_STANDARD"
     "os_disk_type" = "gp2"
     "os_disk_size" = 200
     "os_disk_iops" = 0

--- a/files/custom-data/additional_userdata.sh
+++ b/files/custom-data/additional_userdata.sh
@@ -13,7 +13,7 @@
 ##
 
 # Install needed packages
-yum -y install nvme-cli mdadm
+dnf -y install nvme-cli mdadm
 
 # Setup ENV's for ease of use
 SSD_NVME_DEVICE_LIST=($(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -d " " -f 1 || true))

--- a/test/defaultplan/default_unit_test.go
+++ b/test/defaultplan/default_unit_test.go
@@ -25,7 +25,7 @@ func TestPlanDefaults(t *testing.T) {
 			AttributeJsonPath: "{$.name}",
 		},
 		"k8sVersionTest": {
-			Expected:          "1.31",
+			Expected:          "1.32",
 			ResourceMapName:   "module.eks.aws_eks_cluster.this[0]",
 			AttributeJsonPath: "{$.version}",
 		},

--- a/test/defaultplan/eks_test.go
+++ b/test/defaultplan/eks_test.go
@@ -40,7 +40,7 @@ func TestPlanEKSConfig(t *testing.T) {
 	tests := map[string]helpers.TestCase{
 		// Kubernetes Configuration Tests
 		"kubernetesVersion": {
-			Expected:          "1.31",
+			Expected:          "1.32",
 			ResourceMapName:   "module.eks.aws_eks_cluster.this[0]",
 			AttributeJsonPath: "{$.version}",
 			Message:           "Kubernetes version should match the specified version",

--- a/test/nondefaultplan/nodepool_test.go
+++ b/test/nondefaultplan/nodepool_test.go
@@ -62,7 +62,7 @@ func TestPlanNodePools(t *testing.T) {
 			AssertFunction:    assert.Equal,
 		},
 		"gpuNodePoolCpuType": {
-			Expected:          "AL2_x86_64_GPU",
+			Expected:          "AL2023_x86_64_NVIDIA",
 			ResourceMapName:   "module.eks.module.eks_managed_node_group[\"gpu\"].aws_eks_node_group.this[0]",
 			AttributeJsonPath: "{$.ami_type}",
 			Message:           "GPU node pool should have correct CPU type",
@@ -145,7 +145,7 @@ func TestPlanNodePools(t *testing.T) {
 		variables["node_pools"] = map[string]map[string]interface{}{
 			"gpu": {
 				"vm_type":                              "g4dn.xlarge",
-				"cpu_type":                             "AL2_x86_64_GPU",
+				"cpu_type":                             "AL2023_x86_64_NVIDIA",
 				"os_disk_type":                         "gp2",
 				"os_disk_size":                         100,
 				"os_disk_iops":                         3000,
@@ -160,7 +160,7 @@ func TestPlanNodePools(t *testing.T) {
 			},
 			"high-memory": {
 				"vm_type":                              "r5.2xlarge",
-				"cpu_type":                             "AL2_x86_64",
+				"cpu_type":                             "AL2023_x86_64_STANDARD",
 				"os_disk_type":                         "io1",
 				"os_disk_size":                         200,
 				"os_disk_iops":                         3000,

--- a/variables.tf
+++ b/variables.tf
@@ -175,11 +175,11 @@ variable "efs_throughput_rate" {
 }
 
 ## Kubernetes
-# Kubernetes version for the EKS cluster. Default is '1.31'.
+# Kubernetes version for the EKS cluster. Default is '1.32'.
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version."
   type        = string
-  default     = "1.31"
+  default     = "1.32"
 }
 
 # Map of tags to apply to all resources. Used for cost allocation, project tracking, etc.
@@ -318,7 +318,7 @@ variable "node_pools" {
   default = {
     cas = {
       "vm_type"      = "r6idn.2xlarge"
-      "cpu_type"     = "AL2_x86_64"
+      "cpu_type"     = "AL2023_x86_64_STANDARD"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
       "os_disk_iops" = 0
@@ -335,7 +335,7 @@ variable "node_pools" {
     },
     compute = {
       "vm_type"      = "m6idn.xlarge"
-      "cpu_type"     = "AL2_x86_64"
+      "cpu_type"     = "AL2023_x86_64_STANDARD"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
       "os_disk_iops" = 0
@@ -353,7 +353,7 @@ variable "node_pools" {
     },
     stateless = {
       "vm_type"      = "m6in.xlarge"
-      "cpu_type"     = "AL2_x86_64"
+      "cpu_type"     = "AL2023_x86_64_STANDARD"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
       "os_disk_iops" = 0
@@ -370,7 +370,7 @@ variable "node_pools" {
     },
     stateful = {
       "vm_type"      = "m6in.xlarge"
-      "cpu_type"     = "AL2_x86_64"
+      "cpu_type"     = "AL2023_x86_64_STANDARD"
       "os_disk_type" = "gp2"
       "os_disk_size" = 200
       "os_disk_iops" = 0


### PR DESCRIPTION
### **What is changing**

- Updated the IaC code to support Kubernetes version 1.32, as part of enabling support for v1.33.
- Added use of kubectl 1.32.6 binary to ensure compatibility when deploying clusters on Kubernetes 1.33.
- Changed the default cpu_type to AL2023_x86_64_STANDARD:
  - AWS has announced end-of-life (EOL) for Amazon Linux 2 (AL2) on November 26, 2025.
  - AL2023 is fully supported, compatible with cloud-init, and allows us to keep our existing Terraform custom_data scripts (with minor changes like replacing yum with dnf).
  - This ensures our clusters remain deployable and supported beyond AL2 EOL.

### Tests

|Scenario|Method|K8s cluster version|Postgres|cadence|Deployment Operator|Notes|
|-|-|-|-|-|-|-|
|1|Docker|v1.31.x|External|n/a|Deployment operator Enabled|Successful Viya deployment; all pods running; login as viya_admin|
|2|Docker|v1.32.3|External|n/a|Deployment operator Enabled|Successful Viya deployment; all pods running; login as viya_admin|
|3|Docker|v1.33.0|External|n/a|Deployment operator Enabled overriding kubectl v1.32.6|Successful Viya deployment; all pods running; login as viya_admin|
|4|Docker|v1.31.x|Internal|Internal Crunchy|Deployment operator Enabled|Successful Viya deployment; all pods running; login as viya_admin|
|5|Docker|v1.32.3|Internal|Internal Crunchy|Deployment operator Enabled|Successful Viya deployment; all pods running; login as viya_admin|
|6|Docker|v1.33.0|Internal|Internal Crunchy|Deployment operator Enabled overriding kubectl v1.32.6|Successful Viya deployment; all pods running; login as viya_admin|

### **Why AL2023?**

- Fully supported by AWS for EKS, with ongoing security and AMI updates
- Cloud‑init compatible → continues to support our existing Terraform custom_data shell scripts (with minor changes like replacing yum with dnf)
- Allows us to retain current disk setup logic (partitioning, formatting, RAID) without major refactor
- Low‑risk, quick path to remove AL2 dependency before EOL

### **Why not Bottlerocket ?**

**Bottlerocket requires:**

- Building and publishing a disk‑bootstrap Docker image
- Referencing it in a bootstrap‑containers.toml file
- Passing that TOML config to the nodegroup launch template via Terraform (custom_data)

Only then would Bottlerocket run the container at boot to handle disk setup.
This introduces extra build, registry, and CI/CD complexity we are not ready to take on immediately.