### PR TITLE
fix: getting started with SAS viya and K8s service link (PSCLOUD-103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This project contains Terraform scripts to provision the AWS cloud infrastructur
 [<img src="./docs/images/viya4-iac-aws-diag.png" alt="Architecture Diagram" width="750"/>](./docs/images/viya4-iac-aws-diag.png?raw=true)
 
 This project helps you to automate the cluster-provisioning phase of SAS Viya platform deployment. To learn about all phases and options of the
-SAS Viya platform deployment process, see [Getting Started with SAS Viya and Amazon Elastic Kubernetes Service](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopscon&docsetTarget=p111dd1k5z99kin1f7mciggn9wop.htm) in _SAS&reg; Viya&reg; Platform Operations_.
+SAS Viya platform deployment process, see [Getting Started with SAS Viya and Amazon Elastic Kubernetes Service](https://go.documentation.sas.com/doc/es/sasadmincdc/v_013/itopscon/p111dd1k5z99kin1f7mciggn9wop.htm) in _SAS&reg; Viya&reg; Platform Operations_.
 
 Once the cloud resources are provisioned, use the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) project to deploy
 the SAS Viya platform in your cloud environment. For more information about SAS Viya platform requirements and documentation for the deployment


### PR DESCRIPTION
This PR fixes a broken link in the viya4-iac-aws project that pointed to the "Getting Started with SAS Viya and Amazon Elastic Kubernetes Service" section in the SAS Viya Platform Operations documentation. The outdated URL has been replaced with the correct, working link.