### PR TITLE
fix: add gate for egress rule on security group

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "sg" {
 
 # Egress rule to allow all outbound traffic from the security group
 resource "aws_vpc_security_group_egress_rule" "sg" {
-
+  count = var.security_group_id == null && var.vpc_private_endpoints_enabled ? 1 : 0
   security_group_id = local.security_group_id
 
   description = "Allow all outbound traffic."


### PR DESCRIPTION
When using the bring-your-own-network model, we create the security group ahead of time and pass it to IaC via the security_group_id variable. When updating to the 8.7.0 release of viya4-iac-aws however, the cluster cannot be created because of the following error:

│ Error: creating VPC Security Group Rule
│
│   with aws_vpc_security_group_egress_rule.sg,
│   on security.tf line 28, in resource "aws_vpc_security_group_egress_rule" "sg":
│   28: resource "aws_vpc_security_group_egress_rule" "sg" {
│
│ operation error EC2: AuthorizeSecurityGroupEgress, https response error
│ StatusCode: 400, RequestID: 401c03ce-aecc-4798-8e9f-4199ec09d936, api error
│ InvalidPermission.Duplicate: the specified rule "peer: 0.0.0.0/0, ALL,
│ ALLOW" already exists

The reason is because when the security group is initially created, AWS automatically assigns a default outbound (egress) rule that opens up traffic to all address on all ports (see screenshot below). This causes a conflict however when terraform then attempts to create the aws_security_group resource.

This aws_security_group resource needs to be gated, like the other resources, such that it is only created in situations where viya4-iac-aws is responsible for creating the security group.

<img width="1318" height="136" alt="image" src="https://github.com/user-attachments/assets/c5adaf52-4c38-4bd3-9656-48f286957587" />

