### PR TITLE
feat: support k8s 1.36 (PSCLOUD-1242)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
 FROM almalinux:minimal AS amin
 WORKDIR /app
 USER root
-ARG KUBECTL_VERSION=1.34.6
-ARG KUBECTL_CHECKSUM=3166155b17198c0af34ff5a360bd4d9d58db98bafadc6f3c2a57ae560563cd6b
+ARG KUBECTL_VERSION=1.35.6
+ARG KUBECTL_CHECKSUM=5d11e2ba01ea68ffd053f56e27738e2b4330013ee67f7e46c6da6c585d3c9926
 RUN /usr/bin/bash -eux \
   && curl -fSLO https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl \

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following are also required:
 #### Terraform Requirements:
 
 - [Terraform](https://www.terraform.io/downloads.html) v1.10.5
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.34.6
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) - v1.35.6
 - [jq](https://stedolan.github.io/jq/) v1.6
 - [AWS CLI](https://aws.amazon.com/cli) (optional; useful as an alternative to the AWS Web Console) v2.24.16
 

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -39,7 +39,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-custom-data.tfvars
+++ b/examples/sample-input-custom-data.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-gpu.tfvars
+++ b/examples/sample-input-gpu.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 1
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-multizone.tfvars
+++ b/examples/sample-input-multizone.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-optionalcas.tfvars
+++ b/examples/sample-input-optionalcas.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 ## Cluster config
-kubernetes_version           = "1.34"
+kubernetes_version           = "1.35"
 default_nodepool_node_count  = 2
 default_nodepool_vm_type     = "r6in.2xlarge"
 default_nodepool_custom_data = ""

--- a/test/defaultplan/default_unit_test.go
+++ b/test/defaultplan/default_unit_test.go
@@ -25,7 +25,7 @@ func TestPlanDefaults(t *testing.T) {
 			AttributeJsonPath: "{$.name}",
 		},
 		"k8sVersionTest": {
-			Expected:          "1.34",
+			Expected:          "1.35",
 			ResourceMapName:   "module.eks.aws_eks_cluster.this[0]",
 			AttributeJsonPath: "{$.version}",
 		},

--- a/test/defaultplan/eks_test.go
+++ b/test/defaultplan/eks_test.go
@@ -40,7 +40,7 @@ func TestPlanEKSConfig(t *testing.T) {
 	tests := map[string]helpers.TestCase{
 		// Kubernetes Configuration Tests
 		"kubernetesVersion": {
-			Expected:          "1.34",
+			Expected:          "1.35",
 			ResourceMapName:   "module.eks.aws_eks_cluster.this[0]",
 			AttributeJsonPath: "{$.version}",
 			Message:           "Kubernetes version should match the specified version",

--- a/variables.tf
+++ b/variables.tf
@@ -175,11 +175,11 @@ variable "efs_throughput_rate" {
 }
 
 ## Kubernetes
-# Kubernetes version for the EKS cluster. Default is '1.34'.
+# Kubernetes version for the EKS cluster. Default is '1.35'.
 variable "kubernetes_version" {
   description = "The EKS cluster Kubernetes version."
   type        = string
-  default     = "1.34"
+  default     = "1.35"
 }
 
 # Map of tags to apply to all resources. Used for cost allocation, project tracking, etc.


### PR DESCRIPTION
### **What is changing**

- Updated the IaC code to support Kubernetes version 1.35, as part of enabling support for v1.36.
- Added use of kubectl 1.35.6 binary to ensure compatibility when deploying clusters on Kubernetes 1.36.

### **Tests**

Scenario | Method | K8s cluster version | Postgres | cadence | Deployment Operator | Notes
-- | -- | -- | -- | -- | -- | --
1 | Docker | v1.34 | External | 2026.05 | Deployment operator Enabled | Successful Viya deployment; all pods running; login as viya_admin
2 | Docker | v1.35 | External | 2026.05 | Deployment operator Enabled | Successful Viya deployment; all pods running; login as viya_admin
3 | Docker | v1.36 | External | 2026.05 | Deployment operator Enabled overriding kubectl v1.35.6 | Successful Viya deployment; all pods running; login as viya_admin
4 | Docker | v1.34 | Internal | 2026.05 | Deployment operator Enabled | Successful Viya deployment; all pods running; login as viya_admin
5 | Docker | v1.35 | Internal | 2026.05 | Deployment operator Enabled | Successful Viya deployment; all pods running; login as viya_admin
6 | Docker | v1.36 | Internal | 2026.05 | Deployment operator Enabled overriding kubectl v1.35.6 | Successful Viya deployment; all pods running; login as viya_admin