### PR TITLE
fix: always enable IRSA

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ module "eks" {
   subnet_ids  = module.vpc.private_subnets # Subnets for worker nodes
   vpc_id      = module.vpc.vpc_id          # VPC ID
   tags        = local.tags                 # Common tags
-  enable_irsa = var.autoscaling_enabled    # Enable IAM Roles for Service Accounts if autoscaling
+  enable_irsa = true                       # Enable IRSA required for autoscaling and EBS CSI
   ################################################################################
   # Cluster Security Group
   ################################################################################


### PR DESCRIPTION
The current behavior is that the IAM Role for the Service Account of the EKS cluster is only enabled when autoscaling is enabled.

This is incorrect. Both the autoscaling and ebs module require IRSA to be enabled. Since the ebs module is always enabled, IRSA should also always be enabled. 

Without this change, provisioning EBS volumes fails because the OIDC provider does not exist.